### PR TITLE
Set UK as the default spec of OBAM-OBKM-with-OBBI profile

### DIFF
--- a/docker-compose/obam-obkm-with-obbi/docker-compose.yml
+++ b/docker-compose/obam-obkm-with-obbi/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
     volumes:
-      - "./mysql/scripts/berlin:/docker-entrypoint-initdb.d"
+      - "./mysql/scripts/uk:/docker-entrypoint-initdb.d"
       - "./mysql/scripts/my.cnf:/etc/mysql/my.cnf"
     ulimits:
       nofile:
@@ -104,7 +104,7 @@ services:
       - "mysql"
       - "obbi-worker"
     volumes:
-      - "./obkm/berlin:/home/wso2carbon/wso2-config-volume"
+      - "./obkm/uk:/home/wso2carbon/wso2-config-volume"
       - "./wait-for-it.sh:/home/wso2carbon/wait-for-it.sh"
     ports:
       - "9446:9446"
@@ -130,7 +130,7 @@ services:
       - "obkm"
       - "obbi-worker"
     volumes:
-      - "./obam/berlin:/home/wso2carbon/wso2-config-volume"
+      - "./obam/uk:/home/wso2carbon/wso2-config-volume"
       - "./wait-for-it.sh:/home/wso2carbon/wait-for-it.sh"
     ports:
       - "9443:9443"

--- a/docker-compose/obam-obkm-with-obbi/obam/uk/repository/conf/registry.xml
+++ b/docker-compose/obam-obkm-with-obbi/obam/uk/repository/conf/registry.xml
@@ -44,7 +44,7 @@
 
     <mount path="/_system/config" overwrite="true">
         <instanceId>configInstance</instanceId>
-        <targetPath>/_system/config</targetPath>
+        <targetPath>/_system/obam/config</targetPath>
     </mount>
 
 


### PR DESCRIPTION
## Purpose
> This PR sets UK as the default spec of the above profile instead of Berlin. Fixes https://github.com/wso2/docker-open-banking/issues/34 and https://github.com/wso2/docker-open-banking/issues/33
