### PR TITLE
Failure to accept product startup options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project 1.4.x per each release will be documented in
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v1.4.0.5] - TBA
+
+### Fixed
+- Failure to accept product startup options
+
+For detailed information on the tasks carried out during this release, please see the GitHub milestone
+[v3.0.0.2](https://github.com/wso2/docker-apim/milestone/9).
+
+
 ## [v1.4.0.4] - 2019-10-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Failure to accept product startup options
 
 For detailed information on the tasks carried out during this release, please see the GitHub milestone
-[v3.0.0.2](https://github.com/wso2/docker-apim/milestone/9).
+[v1.4.0.5](https://github.com/wso2/docker-open-banking/milestone/6).
 
 
 ## [v1.4.0.4] - 2019-10-24

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ drivers, extensions and other deployable artifacts are designed to be provided v
 
 Docker Compose resources have been created according to the most common WSO2 Open Banking deployment profiles available for allowing users to quickly evaluate product features along side their co-operate Open Banking requirements. The Compose resources make use of Docker images of WSO2 Open Banking API Manager, WSO2 Open Banking Key Manager and MySQL.
 
-**Change log** from previous v1.4.0.3 release: [View Here](CHANGELOG.md)
+**Change log** from previous v1.4.0.4 release: [View Here](CHANGELOG.md)
 
 ## Reporting issues
 

--- a/dockerfiles/alpine/obam/Dockerfile
+++ b/dockerfiles/alpine/obam/Dockerfile
@@ -72,6 +72,7 @@ RUN \
     && mkdir ${USER_HOME}/wso2-tmp \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \
+    && cp -r ${WSO2_SERVER_HOME}/repository/database ${USER_HOME}/wso2-tmp \
     && rm -f ${WSO2_SERVER}.zip
 
 # set the user and work directory

--- a/dockerfiles/alpine/obam/Dockerfile
+++ b/dockerfiles/alpine/obam/Dockerfile
@@ -61,6 +61,7 @@ COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 # install required packages
 RUN \
     apk add --no-cache \
+        bash \
         libxml2-utils \
         netcat-openbsd
 # add the WSO2 product distribution to user's home directory

--- a/dockerfiles/alpine/obam/Dockerfile
+++ b/dockerfiles/alpine/obam/Dockerfile
@@ -70,6 +70,8 @@ RUN \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \
+    && mkdir ${USER_HOME}/wso2-tmp/deployment \    
+    && mkdir ${USER_HOME}/wso2-tmp/deployment/server \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \
     && cp -r ${WSO2_SERVER_HOME}/repository/database ${USER_HOME}/wso2-tmp \

--- a/dockerfiles/alpine/obam/docker-entrypoint.sh
+++ b/dockerfiles/alpine/obam/docker-entrypoint.sh
@@ -21,7 +21,7 @@ set -e
 config_volume=${WORKING_DIRECTORY}/wso2-config-volume
 artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
 # home of the directories to be artifact synced within the WSO2 product home
-deployment_volume=${WSO2_SERVER_HOME}/repository/deployment/server
+deployment_volume=${WSO2_SERVER_HOME}/repository
 # home of the directories with preserved, default deployment artifacts
 original_deployment_artifacts=${WORKING_DIRECTORY}/wso2-tmp
 
@@ -32,7 +32,7 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-directories=("executionplans" "synapse-configs")
+directories=("deployment/server/executionplans" "deployment/server/synapse-configs" "database")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
 for shared_directory in ${directories[@]}; do

--- a/dockerfiles/alpine/obam/docker-entrypoint.sh
+++ b/dockerfiles/alpine/obam/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ------------------------------------------------------------------------
 # Copyright 2019 WSO2, Inc. (http://wso2.com)
 #
@@ -32,14 +32,13 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-set "executionplans" "synapse-configs"
+directories=("executionplans" "synapse-configs")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
-for shared_directory
-do
+for shared_directory in ${directories[@]}; do
   if test -d ${original_deployment_artifacts}/${shared_directory};
   then
-    if [ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]; then
+    if [[ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]]; then
       if ! cp -R ${original_deployment_artifacts}/${shared_directory}/* ${deployment_volume}/${shared_directory};
       then
         echo "Failed to copy the preserved, default artifacts to original location (${deployment_volume}/${shared_directory})"
@@ -51,9 +50,9 @@ do
 done
 
 # copy any configuration changes mounted to config_volume
-test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
-test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
 sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/alpine/obbi/dashboard/Dockerfile
+++ b/dockerfiles/alpine/obbi/dashboard/Dockerfile
@@ -66,7 +66,7 @@ ENV WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports
-EXPOSE 9449 8006 8007 9444 7712 7612
+EXPOSE 9449 8006 8007 9444 9643 7713 7613
 
 # initiate container and start WSO2 Carbon server
 ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/alpine/obkm/Dockerfile
+++ b/dockerfiles/alpine/obkm/Dockerfile
@@ -83,7 +83,7 @@ ENV JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports
-EXPOSE 9763 9443
+EXPOSE 9763 9443 9446
 
 # initiate container and start WSO2 Carbon server
 ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/ubuntu/obam/Dockerfile
+++ b/dockerfiles/ubuntu/obam/Dockerfile
@@ -74,6 +74,7 @@ RUN \
     && mkdir ${USER_HOME}/wso2-tmp \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \
+    && cp -r ${WSO2_SERVER_HOME}/repository/database ${USER_HOME}/wso2-tmp \
     && rm -f ${WSO2_SERVER}.zip
 
 # set the user and work directory

--- a/dockerfiles/ubuntu/obam/Dockerfile
+++ b/dockerfiles/ubuntu/obam/Dockerfile
@@ -72,8 +72,10 @@ RUN \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \
-    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
-    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \
+    && mkdir ${USER_HOME}/wso2-tmp/deployment \    
+    && mkdir ${USER_HOME}/wso2-tmp/deployment/server \    
+    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp/deployment/server \
+    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp/deployment/server \
     && cp -r ${WSO2_SERVER_HOME}/repository/database ${USER_HOME}/wso2-tmp \
     && rm -f ${WSO2_SERVER}.zip
 

--- a/dockerfiles/ubuntu/obam/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/obam/docker-entrypoint.sh
@@ -21,7 +21,7 @@ set -e
 config_volume=${WORKING_DIRECTORY}/wso2-config-volume
 artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
 # home of the directories to be artifact synced within the WSO2 product home
-deployment_volume=${WSO2_SERVER_HOME}/repository/deployment/server
+deployment_volume=${WSO2_SERVER_HOME}/repository
 # home of the directories with preserved, default deployment artifacts
 original_deployment_artifacts=${WORKING_DIRECTORY}/wso2-tmp
 
@@ -32,7 +32,7 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-directories=("executionplans" "synapse-configs")
+directories=("deployment/server/executionplans" "deployment/server/synapse-configs" "database")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
 for shared_directory in ${directories[@]}; do

--- a/dockerfiles/ubuntu/obam/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/obam/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ------------------------------------------------------------------------
 # Copyright 2019 WSO2, Inc. (http://wso2.com)
 #
@@ -32,14 +32,13 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-set "executionplans" "synapse-configs"
+directories=("executionplans" "synapse-configs")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
-for shared_directory
-do
+for shared_directory in ${directories[@]}; do
   if test -d ${original_deployment_artifacts}/${shared_directory};
   then
-    if [ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]; then
+    if [[ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]]; then
       if ! cp -R ${original_deployment_artifacts}/${shared_directory}/* ${deployment_volume}/${shared_directory};
       then
         echo "Failed to copy the preserved, default artifacts to original location (${deployment_volume}/${shared_directory})"
@@ -51,9 +50,9 @@ do
 done
 
 # copy any configuration changes mounted to config_volume
-test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
-test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
 sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/ubuntu/obbi/dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/obbi/dashboard/Dockerfile
@@ -73,7 +73,7 @@ ENV WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports
-EXPOSE 9713 9643 9613 7713 7613
+EXPOSE 9449 8006 8007 9444 9643 7713 7613
 
 # initiate container and start WSO2 Carbon server
 ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/ubuntu/obkm/Dockerfile
+++ b/dockerfiles/ubuntu/obkm/Dockerfile
@@ -87,7 +87,7 @@ ENV JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports
-EXPOSE 9763 9443
+EXPOSE 9763 9443 9446
 
 # initiate container and start WSO2 Carbon server
 ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]


### PR DESCRIPTION
## Purpose
> It has been discovered that the WSO2 Open Banking API Manager version 1.4.x Docker images fail to accept product startup options. This PR fixes the original issue #43 

## Goals
> Fix failure to accept product startup options