### PR TITLE
Update change log documentation regarding the changes in release v1.4.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@ All notable changes to this project 1.4.x per each release will be documented in
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## [v1.4.0.5] - TBA
+## [v1.4.0.5] - 2019-11-07
 
 ### Fixed
 - Failure to accept product startup options
+- Requirement to preserve the default H2 database data of <OBAM_HOME>/repository/database directory
 
 For detailed information on the tasks carried out during this release, please see the GitHub milestone
 [v1.4.0.5](https://github.com/wso2/docker-open-banking/milestone/6).


### PR DESCRIPTION
## Purpose
> This PR preserves the default H2 database data of <OBAM_HOME>/repository/database directory. Fixes #46.
