### PR TITLE
[1.5.0] Fix Incorrect Port Definitions in OB Key Manager Dockerfiles

### DIFF
--- a/dockerfiles/alpine/obkm/Dockerfile
+++ b/dockerfiles/alpine/obkm/Dockerfile
@@ -86,7 +86,7 @@ ENV JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports
-EXPOSE 9763 9443 9446
+EXPOSE 9766 9446
 
 # initiate container and start WSO2 Carbon server
 ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/ubuntu/obkm/Dockerfile
+++ b/dockerfiles/ubuntu/obkm/Dockerfile
@@ -90,7 +90,7 @@ ENV JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports
-EXPOSE 9763 9443 9446
+EXPOSE 9766 9446
 
 # initiate container and start WSO2 Carbon server
 ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]


### PR DESCRIPTION
## Purpose
> This PR addresses $subject thus fixing the linked issue.

## Goals
> Review and fix incorrect port definitions in OB Key Manager Dockerfiles

## Test environment
> Docker Engine Community version `19.03.5` (both client and server)