### PR TITLE
[1.5.0] Add Support for Data Persistence during Apache based Solr Indexing

### DIFF
--- a/dockerfiles/alpine/obam/Dockerfile
+++ b/dockerfiles/alpine/obam/Dockerfile
@@ -70,11 +70,8 @@ RUN \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \
-    && mkdir ${USER_HOME}/wso2-tmp/deployment \    
-    && mkdir ${USER_HOME}/wso2-tmp/deployment/server \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \
-    && cp -r ${WSO2_SERVER_HOME}/repository/database ${USER_HOME}/wso2-tmp \
     && rm -f ${WSO2_SERVER}.zip
 
 # set the user and work directory

--- a/dockerfiles/alpine/obam/Dockerfile
+++ b/dockerfiles/alpine/obam/Dockerfile
@@ -70,6 +70,8 @@ RUN \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \
+    && bash -c 'mkdir -p ${USER_HOME}/solr/{indexed-data,database}' \
+    && chown wso2carbon:wso2 -R ${USER_HOME}/solr \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \
     && rm -f ${WSO2_SERVER}.zip

--- a/dockerfiles/alpine/obam/docker-entrypoint.sh
+++ b/dockerfiles/alpine/obam/docker-entrypoint.sh
@@ -21,7 +21,7 @@ set -e
 config_volume=${WORKING_DIRECTORY}/wso2-config-volume
 artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
 # home of the directories to be artifact synced within the WSO2 product home
-deployment_volume=${WSO2_SERVER_HOME}/repository
+deployment_volume=${WSO2_SERVER_HOME}/repository/deployment/server
 # home of the directories with preserved, default deployment artifacts
 original_deployment_artifacts=${WORKING_DIRECTORY}/wso2-tmp
 
@@ -32,7 +32,7 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-directories=("deployment/server/executionplans" "deployment/server/synapse-configs" "database")
+directories=("executionplans" "synapse-configs")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
 for shared_directory in ${directories[@]}; do

--- a/dockerfiles/ubuntu/obam/Dockerfile
+++ b/dockerfiles/ubuntu/obam/Dockerfile
@@ -72,11 +72,8 @@ RUN \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \
-    && mkdir ${USER_HOME}/wso2-tmp/deployment \    
-    && mkdir ${USER_HOME}/wso2-tmp/deployment/server \    
-    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp/deployment/server \
-    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp/deployment/server \
-    && cp -r ${WSO2_SERVER_HOME}/repository/database ${USER_HOME}/wso2-tmp \
+    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
+    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \
     && rm -f ${WSO2_SERVER}.zip
 
 # set the user and work directory

--- a/dockerfiles/ubuntu/obam/Dockerfile
+++ b/dockerfiles/ubuntu/obam/Dockerfile
@@ -72,6 +72,8 @@ RUN \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \
+    && bash -c 'mkdir -p ${USER_HOME}/solr/{indexed-data,database}' \
+    && chown wso2carbon:wso2 -R ${USER_HOME}/solr \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \
     && rm -f ${WSO2_SERVER}.zip

--- a/dockerfiles/ubuntu/obam/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/obam/docker-entrypoint.sh
@@ -21,7 +21,7 @@ set -e
 config_volume=${WORKING_DIRECTORY}/wso2-config-volume
 artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
 # home of the directories to be artifact synced within the WSO2 product home
-deployment_volume=${WSO2_SERVER_HOME}/repository
+deployment_volume=${WSO2_SERVER_HOME}/repository/deployment/server
 # home of the directories with preserved, default deployment artifacts
 original_deployment_artifacts=${WORKING_DIRECTORY}/wso2-tmp
 
@@ -32,7 +32,7 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-directories=("deployment/server/executionplans" "deployment/server/synapse-configs" "database")
+directories=("executionplans" "synapse-configs")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
 for shared_directory in ${directories[@]}; do


### PR DESCRIPTION
## Purpose
> This PR performs $subject by creating the empty directories required for the preservation of data generated during Apache based Solr Indexing. This PR fixes the linked issue.

## Goals
> Add Support for Data Persistence during Apache based Solr Indexing

## Test environment
> Docker Engine Community version `19.03.5` (both client and server)