### PR TITLE
Create Dockerfiles for OBAM, OBKM and OBBI for Ubuntu and Alpine for release 2.0.0

### DIFF
--- a/dockerfiles/alpine/obam/Dockerfile
+++ b/dockerfiles/alpine/obam/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to AdoptOpenJDK Alpine Docker image
 FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0.1"
 
 # set Docker image build arguments
 # build arguments for user/group configurations
@@ -64,8 +64,8 @@ RUN \
     apk add --no-cache \
         bash \
         libxml2-utils \
-        unzip \
-        netcat-openbsd
+        netcat-openbsd \
+        unzip
 # add the WSO2 product distribution to user's home directory
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \

--- a/dockerfiles/alpine/obam/Dockerfile
+++ b/dockerfiles/alpine/obam/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u242-b08-alpine
+FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v1.5.0.2"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
 
 # set Docker image build arguments
 # build arguments for user/group configurations
@@ -30,7 +30,7 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2-obam
-ARG WSO2_SERVER_VERSION=1.5.0
+ARG WSO2_SERVER_VERSION=2.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL
@@ -64,6 +64,7 @@ RUN \
     apk add --no-cache \
         bash \
         libxml2-utils \
+        unzip \
         netcat-openbsd
 # add the WSO2 product distribution to user's home directory
 RUN \

--- a/dockerfiles/alpine/obam/README.md
+++ b/dockerfiles/alpine/obam/README.md
@@ -5,7 +5,7 @@ This section defines the step-by-step instructions to build an [Alpine](https://
 
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 Open Banking API Manager pack downloaded through [WUM](https://docs.wso2.com/display/OB150/Setting+Up+Servers)
+* WSO2 Open Banking API Manager pack downloaded through [WUM](https://docs.wso2.com/display/OB200/Setting+Up+Servers)
     + Host the downloaded pack locally or on a remote location.
     > The hosted location will be passed as the build argument `WSO2_SERVER_DIST_URL` when building the Docker image. 
 
@@ -23,13 +23,13 @@ git clone https://github.com/wso2/docker-open-banking.git
 
 - Navigate to `<OBAM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obam:1.5.0-alpine .`
-    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obam-1.5.0.zip -t wso2-obam:1.5.0-alpine .`
-    > eg:- Hosted remotely: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2-obam-1.5.0.zip -t wso2-obam:1.5.0-alpine .`
+    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obam:2.0.0-alpine .`
+    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obam-2.0.0.zip -t wso2-obam:2.0.0-alpine .`
+    > eg:- Hosted remotely: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2-obam-2.0.0.zip -t wso2-obam:2.0.0-alpine .`
     
 ##### 3. Running the Docker image.
 
-- `docker run -it -p 9443:9443 wso2-obam:1.5.0-alpine`
+- `docker run -it -p 9443:9443 wso2-obam:2.0.0-alpine`
 
 ##### 4. Accessing management console.
 
@@ -45,7 +45,7 @@ As an example, steps required to change the port offset using `carbon.xml` is as
 
 ##### 1. Stop the API Manager container if it's already running.
 
-In WSO2 Open Banking API Manager 1.5.0 product distribution, `carbon.xml` configuration file <br>
+In WSO2 Open Banking API Manager 2.0.0 product distribution, `carbon.xml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/carbon.xml` and change the offset value under ports to 1.
 
@@ -61,10 +61,10 @@ chmod o+r <SOURCE_CONFIGS>/carbon.xml
 docker run \
 -p 9444:9444 \
 --volume <SOURCE_CONFIGS>/carbon.xml:<TARGET_CONFIGS>/carbon.xml \
-wso2-obam:1.5.0-alpine
+wso2-obam:2.0.0-alpine
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obam-1.5.0/repository/conf folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obam-2.0.0/repository/conf folder of the container.
 
 ## How to add a custom keystore
 

--- a/dockerfiles/alpine/obbi/dashboard/Dockerfile
+++ b/dockerfiles/alpine/obbi/dashboard/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u242-b08-alpine
+FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v1.5.0.2"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
 
 # set Docker image build arguments
 # build arguments for user/group configurations
@@ -30,7 +30,7 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2-obbi
-ARG WSO2_SERVER_VERSION=1.5.0
+ARG WSO2_SERVER_VERSION=2.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL
@@ -67,7 +67,7 @@ ENV WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports
-EXPOSE 9643
+EXPOSE 9643 9649
 
 # initiate container and start WSO2 Carbon server
 ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/alpine/obbi/dashboard/Dockerfile
+++ b/dockerfiles/alpine/obbi/dashboard/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to AdoptOpenJDK Alpine Docker image
 FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0.1"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/alpine/obbi/dashboard/README.md
+++ b/dockerfiles/alpine/obbi/dashboard/README.md
@@ -1,14 +1,14 @@
 # Dockerfile for Dashboard Profile of WSO2 Open Banking Business Intelligence #
 
 This section defines the step-by-step instructions to build [Alpine](https://hub.docker.com/_/alpine/) Linux based Docker image for Dashboard profile of
-WSO2 Open Banking Business Intelligence 1.5.0.
+WSO2 Open Banking Business Intelligence 2.0.0.
 
 ## Prerequisites
 
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
 
-* WSO2 Open Banking Business Intelligence pack downloaded through [WUM](https://docs.wso2.com/display/OB150/Setting+Up+Servers)
+* WSO2 Open Banking Business Intelligence pack downloaded through [WUM](https://docs.wso2.com/display/OB200/Setting+Up+Servers)
     + Host the downloaded pack locally or on a remote location.
     > The hosted location will be passed as the build argument `WSO2_SERVER_DIST_URL` when building the Docker image. 
 
@@ -26,13 +26,13 @@ git clone https://github.com/wso2/docker-open-banking.git
 
 - Navigate to `<OBBI_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obbi-dashboard:1.5.0-alpine .`
-    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obbi-1.5.0.zip -t wso2-obbi-dashboard:1.5.0-alpine .`
-    > eg:- Hosted remotely: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<pubic_ip:port>/wso2-obbi-1.5.0.zip -t wso2-obbi-dashboard:1.5.0-alpine .`
+    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obbi-dashboard:2.0.0-alpine .`
+    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obbi-2.0.0.zip -t wso2-obbi-dashboard:2.0.0-alpine .`
+    > eg:- Hosted remotely: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<pubic_ip:port>/wso2-obbi-2.0.0.zip -t wso2-obbi-dashboard:2.0.0-alpine .`
     
 ##### 3. Running Docker images specific to each profile.
 
-- `docker run -p 9643:9643 wso2-obbi-dashboard:1.5.0-alpine`
+- `docker run -p 9643:9643 wso2-obbi-dashboard:2.0.0-alpine`
 > Here, only port 9643 has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
 
@@ -50,7 +50,7 @@ As an example, steps required to change the port offset using `deployment.yaml` 
 
 ##### 1. Stop the Open Banking Business Intelligence container if it's already running.
 
-In WSO2 Open Banking Business Intelligence 1.5.0 product distribution, `deployment.yaml` configuration file <br>
+In WSO2 Open Banking Business Intelligence 2.0.0 product distribution, `deployment.yaml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/conf/dashboard`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/deployment.yaml` and change the offset value under ports to 1.
 
@@ -66,10 +66,10 @@ chmod o+r <SOURCE_CONFIGS>/deployment.yaml
 docker run 
 -p 9641:9641
 --volume <SOURCE_CONFIGS>/deployment.yaml:<TARGET_CONFIGS>/deployment.yaml
-wso2-obbi-dashboard:1.5.0-alpine
+wso2-obbi-dashboard:2.0.0-alpine
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obbi-1.5.0/conf/dashboard folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obbi-2.0.0/conf/dashboard folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/alpine/obbi/worker/Dockerfile
+++ b/dockerfiles/alpine/obbi/worker/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u242-b08-alpine
+FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v1.5.0.2"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
 
 # set Docker image build arguments
 # build arguments for user/group configurations
@@ -30,7 +30,7 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2-obbi
-ARG WSO2_SERVER_VERSION=1.5.0
+ARG WSO2_SERVER_VERSION=2.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL
@@ -70,7 +70,7 @@ ENV WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports
-EXPOSE 7444 7712 7612 8006 8007 9444
+EXPOSE 7444 7712 7612 8006 8007 9444 9445
 
 # initiate container and start WSO2 Carbon server
 ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/alpine/obbi/worker/Dockerfile
+++ b/dockerfiles/alpine/obbi/worker/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to AdoptOpenJDK Alpine Docker image
 FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0.1"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/alpine/obbi/worker/README.md
+++ b/dockerfiles/alpine/obbi/worker/README.md
@@ -1,14 +1,14 @@
 # Dockerfile for Worker Profile of WSO2 Open Banking Business Intelligence #
 
 This section defines the step-by-step instructions to build [Alpine](https://hub.docker.com/_/alpine/) Linux based Docker image for Worker profile of
-WSO2 Open Banking Business Intelligence 1.5.0.
+WSO2 Open Banking Business Intelligence 2.0.0.
 
 ## Prerequisites
 
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
 
-* WSO2 Open Banking Business Intelligence pack downloaded through [WUM](https://docs.wso2.com/display/OB150/Setting+Up+Servers)
+* WSO2 Open Banking Business Intelligence pack downloaded through [WUM](https://docs.wso2.com/display/OB200/Setting+Up+Servers)
     + Host the downloaded pack locally or on a remote location.
     > The hosted location will be passed as the build argument `WSO2_SERVER_DIST_URL` when building the Docker image. 
 
@@ -26,13 +26,13 @@ git clone https://github.com/wso2/docker-open-banking.git
 
 - Navigate to `<OBBI_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obbi-worker:1.5.0-alpine .`
-    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obbi-1.5.0.zip -t wso2-obbi-worker:1.5.0-alpine .`
-    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2-obbi-1.5.0.zip -t wso2-obbi-worker:1.5.0-alpine .`
+    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obbi-worker:2.0.0-alpine .`
+    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obbi-2.0.0.zip -t wso2-obbi-worker:2.0.0-alpine .`
+    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2-obbi-2.0.0.zip -t wso2-obbi-worker:2.0.0-alpine .`
     
 ##### 3. Running Docker images specific to each profile.
 
-- `docker run -p 9091:9091 wso2-obbi-worker:1.5.0-alpine`
+- `docker run -p 9091:9091 wso2-obbi-worker:2.0.0-alpine`
 > Here, only port 9091 has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
 
@@ -43,7 +43,7 @@ As an example, steps required to change the port offset using `deployment.yaml` 
 
 ##### 1. Stop the Open Banking Business Intelligence container if it's already running.
 
-In WSO2 Open Banking Business Intelligence 1.5.0 product distribution, `deployment.yaml` configuration file <br>
+In WSO2 Open Banking Business Intelligence 2.0.0 product distribution, `deployment.yaml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/conf/worker`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/deployment.yaml` and change the offset value under ports to 2.
 
@@ -59,10 +59,10 @@ chmod o+r <SOURCE_CONFIGS>/deployment.yaml
 docker run 
 -p 7713:7713
 --volume <SOURCE_CONFIGS>/deployment.yaml:<TARGET_CONFIGS>/deployment.yaml
-wso2-obbi-worker:1.5.0-alpine
+wso2-obbi-worker:2.0.0-alpine
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obbi-1.5.0/conf/worker folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obbi-2.0.0/conf/worker folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/alpine/obkm/Dockerfile
+++ b/dockerfiles/alpine/obkm/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u242-b08-alpine
+FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v1.5.0.2"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
 
 # set Docker image build arguments
 # build arguments for user/group configurations
@@ -29,8 +29,8 @@ ARG USER_GROUP=wso2
 ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
-ARG WSO2_SERVER_NAME=wso2-obkm
-ARG WSO2_SERVER_VERSION=1.5.0
+ARG WSO2_SERVER_NAME=wso2-obiam
+ARG WSO2_SERVER_VERSION=2.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL

--- a/dockerfiles/alpine/obkm/Dockerfile
+++ b/dockerfiles/alpine/obkm/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to AdoptOpenJDK Alpine Docker image
 FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0.1"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/alpine/obkm/README.md
+++ b/dockerfiles/alpine/obkm/README.md
@@ -5,7 +5,7 @@ This section defines the step-by-step instructions to build an [Alpine](https://
 
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 Open Banking Key Manager pack downloaded through [WUM](https://docs.wso2.com/display/OB150/Setting+Up+Servers)
+* WSO2 Open Banking Key Manager pack downloaded through [WUM](https://docs.wso2.com/display/OB200/Setting+Up+Servers)
     + Host the downloaded pack locally or on a remote location.
     > The hosted location will be passed as the build argument `WSO2_SERVER_DIST_URL` when building the Docker image. 
 
@@ -23,13 +23,13 @@ git clone https://github.com/wso2/docker-open-banking.git
 
 - Navigate to `<OBKM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obkm:1.5.0-alpine .`
-    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obkm-1.5.0.zip -t wso2-obkm:1.5.0-alpine .`
-    > eg:- Hosted remotely: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2-obkm-1.5.0.zip -t wso2-obkm:1.5.0-alpine .`
+    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obiam:2.0.0-alpine .`
+    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obiam:2.0.0.zip -t wso2-obiam:2.0.0-alpine .`
+    > eg:- Hosted remotely: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2-obiam:2.0.0.zip -t wso2-obiam:2.0.0-alpine .`
     
 ##### 3. Running the Docker image.
 
-- `docker run -it -p 9446:9446 wso2-obkm:1.5.0-alpine`
+- `docker run -it -p 9446:9446 wso2-obiam:2.0.0-alpine`
 
 ##### 4. Accessing management console.
 
@@ -45,7 +45,7 @@ As an example, steps required to change the port offset using `carbon.xml` is as
 
 ##### 1. Stop the Key Manager container if it's already running.
 
-In WSO2 Open Banking Key Manager 1.5.0 product distribution, `carbon.xml` configuration file <br>
+In WSO2 Open Banking Key Manager 2.0.0 product distribution, `carbon.xml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/carbon.xml` and change the offset value under ports to 1.
 
@@ -61,10 +61,10 @@ chmod o+r <SOURCE_CONFIGS>/carbon.xml
 docker run \
 -p 9447:9447 \
 --volume <SOURCE_CONFIGS>/carbon.xml:<TARGET_CONFIGS>/carbon.xml \
-wso2-obkm:1.5.0-alpine
+wso2-obiam:2.0.0-alpine
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obkm-1.5.0/repository/conf folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obiam:2.0.0/repository/conf folder of the container.
 
 ## How to add a custom keystore
 

--- a/dockerfiles/ubuntu/obam/Dockerfile
+++ b/dockerfiles/ubuntu/obam/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:8u242-b08-jdk-hotspot-bionic
+FROM adoptopenjdk:8u262-b10-jdk-hotspot-bionic
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v1.5.0.2"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
 
 # set Docker image build arguments
 # build arguments for user/group configurations
@@ -30,7 +30,7 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2-obam
-ARG WSO2_SERVER_VERSION=1.5.0
+ARG WSO2_SERVER_VERSION=2.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL

--- a/dockerfiles/ubuntu/obam/Dockerfile
+++ b/dockerfiles/ubuntu/obam/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:8u262-b10-jdk-hotspot-bionic
+FROM adoptopenjdk:8u272-b10-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0.1"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/obam/README.md
+++ b/dockerfiles/ubuntu/obam/README.md
@@ -5,7 +5,7 @@ This section defines the step-by-step instructions to build an [Ubuntu](https://
 
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 Open Banking API Manager pack downloaded through [WUM](https://docs.wso2.com/display/OB150/Setting+Up+Servers)
+* WSO2 Open Banking API Manager pack downloaded through [WUM](https://docs.wso2.com/display/OB200/Setting+Up+Servers)
     + Host the downloaded pack locally or on a remote location.
     > The hosted location will be passed as the build argument `WSO2_SERVER_DIST_URL` when building the Docker image. 
 
@@ -23,13 +23,13 @@ git clone https://github.com/wso2/docker-open-banking.git
 
 - Navigate to `<OBAM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obam:1.5.0 .`
-    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obam-1.5.0.zip -t wso2-obam:1.5.0 .`
-    > eg:- Hosted remotely: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2-obam-1.5.0.zip -t wso2-obam:1.5.0 .`
+    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obam:2.0.0 .`
+    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obam-2.0.0.zip -t wso2-obam:2.0.0 .`
+    > eg:- Hosted remotely: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2-obam-2.0.0.zip -t wso2-obam:2.0.0 .`
     
 ##### 3. Running the Docker image.
 
-- `docker run -it -p 9443:9443 wso2-obam:1.5.0`
+- `docker run -it -p 9443:9443 wso2-obam:2.0.0`
 
 ##### 4. Accessing management console.
 
@@ -45,7 +45,7 @@ As an example, steps required to change the port offset using `carbon.xml` is as
 
 ##### 1. Stop the API Manager container if it's already running.
 
-In WSO2 Open Banking API Manager 1.5.0 product distribution, `carbon.xml` configuration file <br>
+In WSO2 Open Banking API Manager 2.0.0 product distribution, `carbon.xml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/carbon.xml` and change the offset value under ports to 1.
 
@@ -61,10 +61,10 @@ chmod o+r <SOURCE_CONFIGS>/carbon.xml
 docker run \
 -p 9444:9444 \
 --volume <SOURCE_CONFIGS>/carbon.xml:<TARGET_CONFIGS>/carbon.xml \
-wso2-obam:1.5.0
+wso2-obam:2.0.0
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obam-1.5.0/repository/conf folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obam-2.0.0/repository/conf folder of the container.
 
 ## How to add a custom keystore
 

--- a/dockerfiles/ubuntu/obbi/dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/obbi/dashboard/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:8u262-b10-jdk-hotspot-bionic
+FROM adoptopenjdk:8u272-b10-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0.1"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/obbi/dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/obbi/dashboard/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:8u242-b08-jdk-hotspot-bionic
+FROM adoptopenjdk:8u262-b10-jdk-hotspot-bionic
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v1.5.0.2"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
 
 # set Docker image build arguments
 # build arguments for user/group configurations
@@ -30,7 +30,7 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2-obbi
-ARG WSO2_SERVER_VERSION=1.5.0
+ARG WSO2_SERVER_VERSION=2.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL
@@ -74,7 +74,7 @@ ENV WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports
-EXPOSE 9643
+EXPOSE 9643 9649
 
 # initiate container and start WSO2 Carbon server
 ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/ubuntu/obbi/dashboard/README.md
+++ b/dockerfiles/ubuntu/obbi/dashboard/README.md
@@ -1,13 +1,13 @@
 # Dockerfile for Dashboard Profile of WSO2 Open Banking Business Intelligence #
 
 This section defines the step-by-step instructions to build [Ubuntu](https://hub.docker.com/_/ubuntu/) Linux based Docker image for Dashboard profile of
-WSO2 Open Banking Business Intelligence 1.5.0.
+WSO2 Open Banking Business Intelligence 2.0.0.
 
 ## Prerequisites
 
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 Open Banking Business Intelligence pack downloaded through [WUM](https://docs.wso2.com/display/OB150/Setting+Up+Servers)
+* WSO2 Open Banking Business Intelligence pack downloaded through [WUM](https://docs.wso2.com/display/OB200/Setting+Up+Servers)
     + Host the downloaded pack locally or on a remote location.
     > The hosted location will be passed as the build argument `WSO2_SERVER_DIST_URL` when building the Docker image. 
 
@@ -25,13 +25,13 @@ git clone https://github.com/wso2/docker-open-banking.git
 
 - Navigate to `<OBBI_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obbi-dashboard:1.5.0 .`
-    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obbi-1.5.0.zip -t wso2-obbi-dashboard:1.5.0 .`
-    > eg:- Hosted remotely: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2-obbi-1.5.0.zip -t wso2-obbi-dashboard:1.5.0 .`
+    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obbi-dashboard:2.0.0 .`
+    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obbi-2.0.0.zip -t wso2-obbi-dashboard:2.0.0 .`
+    > eg:- Hosted remotely: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2-obbi-2.0.0.zip -t wso2-obbi-dashboard:2.0.0 .`
     
 ##### 3. Running Docker image of Dashboard profile.
 
-- `docker run -p 9643:9643 wso2-obbi-dashboard:1.5.0 .`
+- `docker run -p 9643:9643 wso2-obbi-dashboard:2.0.0 .`
 
 ##### 4. Accessing the Dashboard portal.
 
@@ -47,7 +47,7 @@ As an example, steps required to change the port offset using `deployment.yaml` 
 
 ##### 1. Stop the Open Banking Business Intelligence container if it's already running.
 
-In WSO2 Open Banking Business Intelligence 1.5.0 product distribution, `deployment.yaml` configuration file <br>
+In WSO2 Open Banking Business Intelligence 2.0.0 product distribution, `deployment.yaml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/conf/worker`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/deployment.yaml` and change the offset value under ports to 1.
 
@@ -63,10 +63,10 @@ chmod o+r <SOURCE_CONFIGS>/deployment.yaml
 docker run 
 -p 9641:9641
 --volume <SOURCE_CONFIGS>/deployment.yaml:<TARGET_CONFIGS>/deployment.yaml
-wso2-obbi-dashboard:1.5.0
+wso2-obbi-dashboard:2.0.0
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obbi-1.5.0/conf/worker folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obbi-2.0.0/conf/worker folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/ubuntu/obbi/worker/Dockerfile
+++ b/dockerfiles/ubuntu/obbi/worker/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:8u262-b10-jdk-hotspot-bionic
+FROM adoptopenjdk:8u272-b10-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0.1"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/obbi/worker/Dockerfile
+++ b/dockerfiles/ubuntu/obbi/worker/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:8u242-b08-jdk-hotspot-bionic
+FROM adoptopenjdk:8u262-b10-jdk-hotspot-bionic
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v1.5.0.2"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
 
 # set Docker image build arguments
 # build arguments for user/group configurations
@@ -30,7 +30,7 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2-obbi
-ARG WSO2_SERVER_VERSION=1.5.0
+ARG WSO2_SERVER_VERSION=2.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL
@@ -74,7 +74,7 @@ ENV WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports
-EXPOSE 7444 7712 7612 8006 8007 9444
+EXPOSE 7444 7712 7612 8006 8007 9444 9445
 
 # initiate container and start WSO2 Carbon server
 ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/ubuntu/obbi/worker/README.md
+++ b/dockerfiles/ubuntu/obbi/worker/README.md
@@ -1,13 +1,13 @@
 # Dockerfile for Worker Profile of WSO2 Open Banking Business Intelligence #
 
 This section defines the step-by-step instructions to build [Ubuntu](https://hub.docker.com/_/ubuntu/) Linux based Docker image for Worker profile of
-WSO2 Open Banking Business Intelligence 1.5.0.
+WSO2 Open Banking Business Intelligence 2.0.0.
 
 ## Prerequisites
 
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 Open Banking Business Intelligence pack downloaded through [WUM](https://docs.wso2.com/display/OB150/Setting+Up+Servers)
+* WSO2 Open Banking Business Intelligence pack downloaded through [WUM](https://docs.wso2.com/display/OB200/Setting+Up+Servers)
     + Host the downloaded pack locally or on a remote location.
     > The hosted location will be passed as the build argument `WSO2_SERVER_DIST_URL` when building the Docker image. 
 
@@ -25,13 +25,13 @@ git clone https://github.com/wso2/docker-open-banking.git
 
 - Navigate to `<OBBI_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obbi-worker:1.5.0 .`
-    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obbi-1.5.0.zip -t wso2-obbi-worker:1.5.0 .`
-    > eg:- Hosted remotely: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2-obbi-1.5.0.zip -t wso2-obbi-worker:1.5.0 .`
+    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obbi-worker:2.0.0 .`
+    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obbi-2.0.0.zip -t wso2-obbi-worker:2.0.0 .`
+    > eg:- Hosted remotely: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2-obbi-2.0.0.zip -t wso2-obbi-worker:2.0.0 .`
     
 ##### 3. Running Docker images of worker profile.
 
-- `docker run -p 9091:9091 wso2-obbi-worker:1.5.0`
+- `docker run -p 9091:9091 wso2-obbi-worker:2.0.0`
 > Here, only port 9091 has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
 
@@ -42,7 +42,7 @@ As an example, steps required to change the port offset using `deployment.yaml` 
 
 ##### 1. Stop the Open Banking Business Intelligence container if it's already running.
 
-In WSO2 Open Banking Business Intelligence 1.5.0 product distribution, `deployment.yaml` configuration file <br>
+In WSO2 Open Banking Business Intelligence 2.0.0 product distribution, `deployment.yaml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/conf/worker`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/deployment.yaml` and change the offset value under ports to 2.
 
@@ -58,10 +58,10 @@ chmod o+r <SOURCE_CONFIGS>/deployment.yaml
 docker run 
 -p 7713:7713
 --volume <SOURCE_CONFIGS>/deployment.yaml:<TARGET_CONFIGS>/deployment.yaml
-wso2-obbi-worker:1.5.0
+wso2-obbi-worker:2.0.0
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obbi-1.5.0/conf/worker folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obbi-2.0.0/conf/worker folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/ubuntu/obkm/Dockerfile
+++ b/dockerfiles/ubuntu/obkm/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:8u262-b10-jdk-hotspot-bionic
+FROM adoptopenjdk:8u272-b10-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0.1"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/obkm/Dockerfile
+++ b/dockerfiles/ubuntu/obkm/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:8u242-b08-jdk-hotspot-bionic
+FROM adoptopenjdk:8u262-b10-jdk-hotspot-bionic
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v1.5.0.2"
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v2.0.0"
 
 # set Docker image build arguments
 # build arguments for user/group configurations
@@ -29,8 +29,8 @@ ARG USER_GROUP=wso2
 ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
-ARG WSO2_SERVER_NAME=wso2-obkm
-ARG WSO2_SERVER_VERSION=1.5.0
+ARG WSO2_SERVER_NAME=wso2-obiam
+ARG WSO2_SERVER_VERSION=2.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL

--- a/dockerfiles/ubuntu/obkm/README.md
+++ b/dockerfiles/ubuntu/obkm/README.md
@@ -5,7 +5,7 @@ This section defines the step-by-step instructions to build an [Ubuntu](https://
 
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 Open Banking Key Manager pack downloaded through [WUM](https://docs.wso2.com/display/OB150/Setting+Up+Servers)
+* WSO2 Open Banking Key Manager pack downloaded through [WUM](https://docs.wso2.com/display/OB200/Setting+Up+Servers)
     + Host the downloaded pack locally or on a remote location.
     > The hosted location will be passed as the build argument `WSO2_SERVER_DIST_URL` when building the Docker image.
 
@@ -23,13 +23,13 @@ git clone https://github.com/wso2/docker-open-banking.git
 
 - Navigate to `<OBKM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obkm:1.5.0 .`
-    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obkm-1.5.0.zip -t wso2-obkm:1.5.0 .`
-    > eg:- Hosted remotely: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2-obkm-1.5.0.zip -t wso2-obkm:1.5.0 .`
+    + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obiam:2.0.0 .`
+    > eg:- Hosted locally: `docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2-obiam:2.0.0.zip -t wso2-obiam:2.0.0 .`
+    > eg:- Hosted remotely: `docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2-obiam:2.0.0.zip -t wso2-obiam:2.0.0 .`
 
 ##### 3. Running the Docker image.
 
-- `docker run -it -p 9446:9446 wso2-obkm:1.5.0`
+- `docker run -it -p 9446:9446 wso2-obiam:2.0.0`
 
 ##### 4. Accessing management console.
 
@@ -45,7 +45,7 @@ As an example, steps required to change the port offset using `carbon.xml` is as
 
 ##### 1. Stop the Key Manager container if it's already running.
 
-In WSO2 Open Banking Key Manager 1.5.0 product distribution, `carbon.xml` configuration file <br>
+In WSO2 Open Banking Key Manager 2.0.0 product distribution, `carbon.xml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/carbon.xml` and change the offset value under ports to 1.
 
@@ -61,10 +61,10 @@ chmod o+r <SOURCE_CONFIGS>/carbon.xml
 docker run \
 -p 9447:9447 \
 --volume <SOURCE_CONFIGS>/carbon.xml:<TARGET_CONFIGS>/carbon.xml \
-wso2-obkm:1.5.0
+wso2-obiam:2.0.0
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obkm-1.5.0/repository/conf folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2-obiam:2.0.0/repository/conf folder of the container.
 
 ## How to add a custom keystore
 


### PR DESCRIPTION
## Purpose
Create Dockerfiles for OBAM, OBKM and OBBI for Ubuntu based on adoptopenjdk:8u272-b10-jdk-hotspot-focal image and for Alpine based on adoptopenjdk/openjdk8:jdk8u272-b10-alpine image. This fixes #90 

## Goals
Create Dockerfiles for OBAM, OBKM and OBBI to start the servers with default configurations

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Test environment
Ubuntu, Alpine with mentioned JDKs above.