### PR TITLE
Use the relevant deployment.toml file as per the base product version in UK docker images

### DIFF
--- a/dockerfiles/alpine/obam-uk/Dockerfile
+++ b/dockerfiles/alpine/obam-uk/Dockerfile
@@ -77,7 +77,7 @@ RUN \
 # read deployment.toml file
 ARG DEPLOYMENT_TOML_FILE=${WSO2_OB_TOOLKIT_DIR}/repository/resources/deployment.toml
 RUN \
-    cp ${WSO2_OB_TOOLKIT_DIR}/repository/resources/wso2am-4.0.0-deployment-uk.toml ${DEPLOYMENT_TOML_FILE} \
+    cp ${WSO2_OB_TOOLKIT_DIR}/repository/resources/${WSO2_SERVER}-deployment-uk.toml ${DEPLOYMENT_TOML_FILE} \
 # configure hostnames
     && sed -i -e 's|IS_HOSTNAME|'${IS_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
     && sed -i -e 's|APIM_HOSTNAME|'${APIM_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \

--- a/dockerfiles/alpine/obiam-uk/Dockerfile
+++ b/dockerfiles/alpine/obiam-uk/Dockerfile
@@ -77,7 +77,7 @@ RUN \
 # read deployment.toml file
 ARG DEPLOYMENT_TOML_FILE=${WSO2_OB_TOOLKIT_DIR}/repository/resources/deployment.toml
 RUN \
-    cp ${WSO2_OB_TOOLKIT_DIR}/repository/resources/wso2is-5.11.0-deployment-uk.toml ${DEPLOYMENT_TOML_FILE} \
+    cp ${WSO2_OB_TOOLKIT_DIR}/repository/resources/${WSO2_SERVER}-deployment-uk.toml ${DEPLOYMENT_TOML_FILE} \
 # configure hostnames
     && sed -i -e 's|IS_HOSTNAME|'${IS_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
     && sed -i -e 's|APIM_HOSTNAME|'${APIM_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \

--- a/dockerfiles/ubuntu/obam-uk/Dockerfile
+++ b/dockerfiles/ubuntu/obam-uk/Dockerfile
@@ -83,7 +83,7 @@ RUN \
 # read deployment.toml file
 ARG DEPLOYMENT_TOML_FILE=${WSO2_OB_TOOLKIT_DIR}/repository/resources/deployment.toml
 RUN \
-    cp ${WSO2_OB_TOOLKIT_DIR}/repository/resources/wso2am-4.0.0-deployment-uk.toml ${DEPLOYMENT_TOML_FILE} \
+    cp ${WSO2_OB_TOOLKIT_DIR}/repository/resources/${WSO2_SERVER}-deployment-uk.toml ${DEPLOYMENT_TOML_FILE} \
 # configure hostnames
     && sed -i -e 's|IS_HOSTNAME|'${IS_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
     && sed -i -e 's|APIM_HOSTNAME|'${APIM_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \

--- a/dockerfiles/ubuntu/obiam-uk/Dockerfile
+++ b/dockerfiles/ubuntu/obiam-uk/Dockerfile
@@ -76,7 +76,7 @@ RUN \
 # read deployment.toml file
 ARG DEPLOYMENT_TOML_FILE=${WSO2_OB_TOOLKIT_DIR}/repository/resources/deployment.toml
 RUN \
-    cp ${WSO2_OB_TOOLKIT_DIR}/repository/resources/wso2is-5.11.0-deployment-uk.toml ${DEPLOYMENT_TOML_FILE} \
+    cp ${WSO2_OB_TOOLKIT_DIR}/repository/resources/${WSO2_SERVER}-deployment-uk.toml ${DEPLOYMENT_TOML_FILE} \
 # configure hostnames
     && sed -i -e 's|IS_HOSTNAME|'${IS_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
     && sed -i -e 's|APIM_HOSTNAME|'${APIM_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \


### PR DESCRIPTION
## Purpose
> This PR facilitates will make it possible to use the relevant deployment.toml file as per the base product version that is passed as a build argument while build the UK docker images.
