### PR TITLE
Add jdk17 open banking dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Docker Compose resources have been created according to the most common WSO2 Ope
 │     └── obiam-uk (jdk11)
 └── jdk17
       ├── alpine
-      ├── obiam
+      │     ├── obiam
       │     └── obiam-uk
       └── ubuntu
             ├── obiam

--- a/README.md
+++ b/README.md
@@ -11,6 +11,34 @@ drivers, extensions and other deployable artifacts are designed to be provided v
 
 Docker Compose resources have been created according to the most common WSO2 Open Banking deployment profiles available for allowing users to quickly evaluate product features along side their co-operate Open Banking requirements. The Compose resources make use of Docker images of WSO2 Open Banking API Manager, WSO2 Open Banking Identity & Access Management Module and MySQL.
 
+## Dockerfiles Structure
+
+  Outer alpine & ubuntu directories contain the dockerfiles with default jdk versions. The default jdk version of an OB product is the same the base product default jdk version. The default jdk version is mentioned within the brackets below. For other jdk versions, seperate directoriers are maintained.
+
+```bash
+├── alpine
+│     ├── obam (jdk17)
+│     ├── obam-uk (jdk17)
+│     ├── obbi (jdk17)
+│     ├── obbi-uk (jdk17)
+│     ├── obiam (jdk11)
+│     └── obiam-uk (jdk11)
+├── ubuntu
+│     ├── obam (jdk17)
+│     ├── obam-uk (jdk11)
+│     ├── obbi (jdk17)
+│     ├── obbi-uk (jdk17)
+│     ├── obiam (jdk11)
+│     └── obiam-uk (jdk11)
+└── jdk17
+      ├── alpine
+      ├── obiam
+      │     └── obiam-uk
+      └── ubuntu
+            ├── obiam
+            └── obiam-uk
+```
+
 ## Contributions
 
 For details on how to contribute to this repository, please refer [this](CONTRIBUTING.md) documentation.

--- a/dockerfiles/jdk17/alpine/obiam-uk/Dockerfile
+++ b/dockerfiles/jdk17/alpine/obiam-uk/Dockerfile
@@ -1,0 +1,116 @@
+# ----------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# ----------------------------------------------------------------------------------------
+
+ARG BASE_DOCKER_IMAGE_REGISTRY="docker.wso2.com"
+ARG BASE_PRODUCT_VERSION
+ARG ACCELERATOR_PRODUCT_VERSION=3.0.0.0-is${BASE_PRODUCT_VERSION}.0-alpine-jdk17
+# set base Docker image to WSO2 Open Banking Identity Server Alpine Docker image
+FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2-obiam:${ACCELERATOR_PRODUCT_VERSION}
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v3.0.0.10"
+
+# set Docker image build arguments
+# build arguments for user/group configurations
+ARG USER=wso2carbon
+ARG USER_ID=802
+ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=802
+ARG USER_HOME=/home/${USER}
+# build arguments for WSO2 product installation
+ARG WSO2_SERVER_NAME=wso2is
+# declaring again BASE_PRODUCT_VERSION ARG to use in build stage
+ARG BASE_PRODUCT_VERSION
+ARG WSO2_OB_TOOLKIT_NAME=wso2-obiam-toolkit-uk
+ARG WSO2_OB_TOOLKIT_VERSION=1.0.0
+ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${BASE_PRODUCT_VERSION}
+ARG WSO2_OB_TOOLKIT=${WSO2_OB_TOOLKIT_NAME}-${WSO2_OB_TOOLKIT_VERSION}
+ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
+ARG WSO2_OB_TOOLKIT_DIR=${WSO2_SERVER_HOME}/${WSO2_OB_TOOLKIT}
+ARG WSO2_OB_TOOLKIT_DIST_URL
+# build argument for MOTD
+ARG MOTD='printf "\n\
+ Welcome to WSO2 Docker Resources \n\
+ --------------------------------- \n\
+ This Docker container comprises of The WSO2 Open Banking Solution, with its latest GA release \n\
+ which is under The WSO2 Commercial License 1.0. \n\
+ Read more about The WSO2 Commercial License, Version 1.0 here @ http://wso2.com/licenses \n"'
+ENV ENV=${USER_HOME}"/.ashrc"
+
+# configuration properties for deployment.toml file
+# server hostnames
+ARG IS_HOSTNAME=obiam
+ARG APIM_HOSTNAME=obam
+ARG BI_HOSTNAME=obbi
+# databases related properties
+ARG DB_TYPE=mysql
+ARG DB_USER=root
+ARG DB_PASS=root
+ARG DB_HOST=mysql
+ARG DB_DRIVER=com.mysql.jdbc.Driver
+ARG DB_APIMGT=openbank_apimgtdb
+ARG DB_USER_STORE=openbank_userdb
+ARG DB_AM_CONFIG=openbank_am_configdb
+ARG DB_GOV=openbank_govdb
+ARG DB_IS_CONFIG=openbank_iskm_configdb
+ARG DB_OPEN_BANKING_STORE=openbank_openbankingdb
+ARG DB_OB_REPORTING=openbank_ob_reporting_statsdb
+ARG DB_OB_REPORTING_SUMMARIZED=openbank_ob_reporting_summarizeddb
+
+# change user to root for elevated permissions to override inherited non-root user
+USER root
+
+# add Open Banking artifacts to base product
+RUN \
+    wget -O ${WSO2_OB_TOOLKIT}.zip "${WSO2_OB_TOOLKIT_DIST_URL}" \
+    && unzip -d ${WSO2_SERVER_HOME}/ ${WSO2_OB_TOOLKIT}.zip \
+    && rm -f ${WSO2_OB_TOOLKIT}.zip 
+
+# set configurations
+# read deployment.toml file
+ARG DEPLOYMENT_TOML_FILE=${WSO2_OB_TOOLKIT_DIR}/repository/resources/deployment.toml
+RUN \
+    cp ${WSO2_OB_TOOLKIT_DIR}/repository/resources/${WSO2_SERVER}-deployment-uk.toml ${DEPLOYMENT_TOML_FILE} \
+# configure hostnames
+    && sed -i -e 's|IS_HOSTNAME|'${IS_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|APIM_HOSTNAME|'${APIM_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|BI_HOSTNAME|'${BI_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
+# configure datasources
+    && sed -i -e 's|DB_APIMGT_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_APIMGT}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_GOV_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_GOV}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_IS_CONFIG_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_IS_CONFIG}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_USER_STORE_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_USER_STORE}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_OB_STORE_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_OPEN_BANKING_STORE}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_USER|'${DB_USER}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_PASS|'${DB_PASS}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_DRIVER|'${DB_DRIVER}'|g' ${DEPLOYMENT_TOML_FILE} \
+# copy deployment.toml file to original product pack location
+    && cp ${DEPLOYMENT_TOML_FILE} ${WSO2_SERVER_HOME}/repository/conf/ \
+    && rm ${DEPLOYMENT_TOML_FILE}
+
+# copy the WSO2 OB IAM UK Toolkit artifacts on top of WSO2 IS base product
+# copy open banking artifacts
+RUN\
+    cp -r ${WSO2_OB_TOOLKIT_DIR}/carbon-home/* "${WSO2_SERVER_HOME}"
+
+# change directory rights
+RUN chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME}/
+
+# set the non-root user
+USER ${USER_ID}
+
+# set MOTD login message for open banking
+RUN echo ${MOTD} > "${ENV}"
+
+# expose ports
+EXPOSE 9446
+
+# initiate container and start WSO2 Carbon server
+ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/jdk17/alpine/obiam-uk/README.md
+++ b/dockerfiles/jdk17/alpine/obiam-uk/README.md
@@ -1,0 +1,79 @@
+# Dockerfile for WSO2 Open Banking Identity & Access Management UK Toolkit Module
+This section defines the step-by-step instructions to build an [Alpine](https://hub.docker.com/_/alpine/) Linux based Docker image for WSO2 Open Banking Identity & Access Management UK Toolkit Module with WSO2 IS 6.0.0.
+
+## Prerequisites
+
+* [Docker](https://www.docker.com/get-docker) v20.10.10 or above
+* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
+* WSO2 Open Banking Identity & Access Management UK Toolkit Module pack 
+* Download the WSO2 IS Connector to configure the Identity Server with the API Manager. Please go through this [link](https://ob.docs.wso2.com/en/latest/get-started/quick-start-guide/#installing-base-products) to find respective WSO2 IS Connector according to the API Manager version. Extract the dowloaded WSO2 IS Connector into your local machine.
+    + Host the downloaded artifacts locally or on a remote location.
+    > The hosted locations of artifacts will be passed as the build arguments when building the Docker image.<br>
+    > 1. **WSO2_OB_TOOLKIT_DIST_URL** - UK Toolkit location
+
+## How to build an image and run
+
+##### 1. Checkout this repository into your local machine using the following Git client command.
+
+```
+git clone https://github.com/wso2/docker-open-banking.git
+```
+
+> The local copy of the `jdk17/dockerfiles/alpine/obiam-uk` directory will be referred to as `OBIAM_UK_DOCKERFILE_HOME` from this point onwards.
+
+##### 2. Build the Docker image.
+
+- Navigate to `<OBIAM_UK_DOCKERFILE_HOME>` directory. <br>
+  Execute `docker build` command as shown below.
+    + `docker build --build-arg BASE_PRODUCT_VERSION=<IS BASE PRODUCT VERSION> --build-arg WSO2_OB_TOOLKIT_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obiam-uk:1.0.0-alpine-jdk17 .` <br>
+    > eg:- **Hosted locally**: `docker build --build-arg BASE_PRODUCT_VERSION=6.0.0 --build-arg WSO2_OB_TOOLKIT_DIST_URL=http://localhost:8000/wso2-obiam-toolkit-uk-1.0.0.tar.gz -t wso2-obiam-uk:1.0.0-alpine-jdk17 .` <br><br>
+    > eg:- **Hosted remotely**: `docker build --build-arg BASE_PRODUCT_VERSION=6.0.0 --build-arg WSO2_OB_TOOLKIT_DIST_URL=http://<public_ip:port>/wso2-obiam-toolkit-uk-1.0.0.tar.gz -t wso2-obiam-uk:1.0.0-alpine-jdk17 .`
+
+##### 3. Running the Docker image.
+if you are only using the WSO2 Open Banking Identity Server, please run the below command.
+> - `docker run -it -p 9446:9446 wso2-obiam-uk:1.0.0-alpine-jdk17`
+
+If you are using WSO2 Open Banking Identity Server and WSO2 Open Banking API Manager,  please run the below command.
+> - `docker run -it -p 9446:9446 -v <IS_CONNECTOR_HOME>/dropins:/home/wso2carbon/wso2-artifact-volume/repository/components/dropins/ -v <IS_CONNECTOR_HOME>/webapps:/home/wso2carbon/wso2-artifact-volume/repository/deployment/server/webapps/ wso2-obiam-uk:1.0.0-alpine-jdk17`
+> In here, <IS_CONNECTOR_HOME> refers to the root directory path of the extracted WSO2 IS Connector.
+
+##### 4. Accessing management console.
+
+- To access the management console, use the docker host IP and port 9446.
+    + `https:<DOCKER_HOST>:9446/carbon`
+    
+> In here, <DOCKER_HOST> refers to hostname or IP of the host machine on top of which containers are spawned.
+
+## How to update configurations
+
+Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
+As an example, steps required to change the port offset using `deployment.toml` is as follows:
+
+##### 1. Stop the Identity & Access Management Module container if it's already running.
+
+In WSO2 Open Banking Identity & Access Management UK Toolkit 1.0.0 product distribution, `deployment.toml` configuration file <br>
+can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
+referred to as `<SOURCE_CONFIGS>/deployment.toml` and change the offset value under ports to 1.
+
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/deployment.toml`.
+
+```
+chmod o+r <SOURCE_CONFIGS>/deployment.toml
+```
+
+##### 3. Run the image by mounting the file to container as follows:
+
+```
+docker run \
+-p 9447:9447 \
+--volume <SOURCE_CONFIGS>/deployment.toml:<TARGET_CONFIGS>/deployment.toml \
+wso2-obiam-uk:1.0.0-alpine-jdk17
+```
+
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2is-5.11.0/repository/conf folder of the container.
+
+## Docker command usage references
+
+* [Docker build command reference](https://docs.docker.com/engine/reference/commandline/build/)
+* [Docker run command reference](https://docs.docker.com/engine/reference/run/)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)

--- a/dockerfiles/jdk17/alpine/obiam/Dockerfile
+++ b/dockerfiles/jdk17/alpine/obiam/Dockerfile
@@ -1,0 +1,139 @@
+# ----------------------------------------------------------------------------------------
+#
+# Copyright (c) 2022-2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# ----------------------------------------------------------------------------------------
+
+ARG BASE_DOCKER_IMAGE_REGISTRY="docker.wso2.com"
+ARG BASE_PRODUCT_VERSION
+
+# set base Docker image to WSO2 Identity Server Alpine Docker image
+FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2is:${BASE_PRODUCT_VERSION}.0-alpine-jdk17
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v3.0.0.10"
+
+# set Docker image build arguments
+# build arguments for user/group configurations
+ARG USER=wso2carbon
+ARG USER_ID=802
+ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=802
+ARG USER_HOME=/home/${USER}
+# build arguments for WSO2 product installation
+ARG WSO2_SERVER_NAME=wso2is
+# declaring again BASE_PRODUCT_VERSION ARG to use in build stage
+ARG BASE_PRODUCT_VERSION
+ARG WSO2_OB_ACCELERATOR_NAME=wso2-obiam-accelerator
+ARG WSO2_OB_ACCELERATOR_VERSION=3.0.0
+ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${BASE_PRODUCT_VERSION}
+ARG WSO2_OB_ACCELERATOR=${WSO2_OB_ACCELERATOR_NAME}-${WSO2_OB_ACCELERATOR_VERSION}
+ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
+ARG WSO2_OB_ACCELERATOR_DIR=${WSO2_SERVER_HOME}/${WSO2_OB_ACCELERATOR}
+ARG WSO2_OB_ACCELERATOR_DIST_URL
+ARG OB_TRUSTED_CERTS_URL
+ARG WSO2_OB_KEYSTORES_URL
+# build argument for MOTD
+ARG MOTD='printf "\n\
+ Welcome to WSO2 Docker Resources \n\
+ --------------------------------- \n\
+ This Docker container comprises of The WSO2 Open Banking Solution, with its latest GA release \n\
+ which is under The WSO2 Commercial License 1.0. \n\
+ Read more about The WSO2 Commercial License, Version 1.0 here @ http://wso2.com/licenses \n"'
+ENV ENV=${USER_HOME}"/.ashrc"
+
+# configuration properties for deployment.toml file
+# server hostnames
+ARG IS_HOSTNAME=obiam
+ARG APIM_HOSTNAME=obam
+ARG BI_HOSTNAME=obbi
+# databases related properties
+ARG DB_TYPE=mysql
+ARG DB_USER=root
+ARG DB_PASS=root
+ARG DB_HOST=mysql
+ARG DB_DRIVER=com.mysql.jdbc.Driver
+ARG DB_APIMGT=openbank_apimgtdb
+ARG DB_USER_STORE=openbank_userdb
+ARG DB_AM_CONFIG=openbank_am_configdb
+ARG DB_GOV=openbank_govdb
+ARG DB_IS_CONFIG=openbank_iskm_configdb
+ARG DB_OPEN_BANKING_STORE=openbank_openbankingdb
+ARG DB_OB_REPORTING=openbank_ob_reporting_statsdb
+ARG DB_OB_REPORTING_SUMMARIZED=openbank_ob_reporting_summarizeddb
+
+# change user to root for elevated permissions to override inherited non-root user
+USER root
+
+# add Open Banking artifacts to base product
+RUN \
+    wget -O ${WSO2_OB_ACCELERATOR}.zip "${WSO2_OB_ACCELERATOR_DIST_URL}" \
+    && unzip -d ${WSO2_SERVER_HOME}/ ${WSO2_OB_ACCELERATOR}.zip \
+    && rm -f ${WSO2_OB_ACCELERATOR}.zip \
+    && wget -O ob-cert.zip "${OB_TRUSTED_CERTS_URL}" \
+    && unzip -d ${USER_HOME} ob-cert.zip  \
+    && rm -f ob-cert.zip 
+
+# add keystores to base product 
+RUN if [ -n "$WSO2_OB_KEYSTORES_URL" ]; then wget -O private-keys.jks "${WSO2_OB_KEYSTORES_URL}/private-keys.jks"  \
+    && yes | keytool -importkeystore -srckeystore ${USER_HOME}/private-keys.jks -destkeystore ${WSO2_SERVER_HOME}/repository/resources/security/wso2carbon.jks -srcalias wso2carbon-obiam -destalias wso2carbon -srcstorepass wso2carbon -deststorepass wso2carbon \
+    && rm -f private-keys.jks\
+    && wget -O public-certs.jks "${WSO2_OB_KEYSTORES_URL}/public-certs.jks" \
+    && keytool -importkeystore -srckeystore ${USER_HOME}/public-certs.jks -destkeystore ${WSO2_SERVER_HOME}/repository/resources/security/client-truststore.jks -srcstorepass wso2carbon -deststorepass wso2carbon \
+    && rm -r public-certs.jks ; fi 
+
+# set configurations
+# read deployment.toml file
+ARG DEPLOYMENT_TOML_FILE=${WSO2_OB_ACCELERATOR_DIR}/repository/resources/deployment.toml
+RUN \
+    cp ${WSO2_OB_ACCELERATOR_DIR}/repository/resources/${WSO2_SERVER}-deployment.toml ${DEPLOYMENT_TOML_FILE} \
+# configure hostnames
+    && sed -i -e 's|IS_HOSTNAME|'${IS_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|APIM_HOSTNAME|'${APIM_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|BI_HOSTNAME|'${BI_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
+# configure datasources
+    && sed -i -e 's|DB_APIMGT_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_APIMGT}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_GOV_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_GOV}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_IS_CONFIG_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_IS_CONFIG}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_USER_STORE_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_USER_STORE}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_OB_STORE_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_OPEN_BANKING_STORE}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_USER|'${DB_USER}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_PASS|'${DB_PASS}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_DRIVER|'${DB_DRIVER}'|g' ${DEPLOYMENT_TOML_FILE} \
+# copy deployment.toml file to original product pack location
+    && cp ${DEPLOYMENT_TOML_FILE} ${WSO2_SERVER_HOME}/repository/conf/ \
+    && rm ${DEPLOYMENT_TOML_FILE}
+
+# copy the WSO2 OBIAM accelerator artifacts on top of WSO2 IS base product
+# remove old open banking artifacts from base product
+RUN \
+    find ${WSO2_SERVER_HOME}/repository/components/dropins -name "com.wso2.openbanking.*" -exec rm -rf {} \; \
+    && find ${WSO2_SERVER_HOME}/repository/components/lib -name "com.wso2.openbanking.*" -exec rm -rf {} \; \
+# copy open banking artifacts
+    && cp -r ${WSO2_OB_ACCELERATOR_DIR}/carbon-home/* ${WSO2_SERVER_HOME}/ \
+    && find ${WSO2_SERVER_HOME}/repository/components/dropins -name "org.wso2.carbon.identity.application.authentication.handler.identifier-*" -exec rm -rf {} \; 
+
+# add root and issuer certificates to client-truststore.jks
+RUN \
+    yes | keytool -import -alias ob-root -file root.cer -storetype JKS -keystore ${WSO2_SERVER_HOME}/repository/resources/security/client-truststore.jks  -storepass wso2carbon \
+    && yes | keytool -import -alias ob-issuer -file iss.cer -storetype JKS -keystore ${WSO2_SERVER_HOME}/repository/resources/security/client-truststore.jks  -storepass wso2carbon \
+    && rm -f root.cer iss.cer
+
+# change directory rights
+RUN chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME}/
+
+# set the non-root user
+USER ${USER_ID}
+
+# set MOTD login message for open banking
+RUN echo ${MOTD} > "${ENV}"
+
+# expose ports
+EXPOSE 9446
+
+# initiate container and start WSO2 Carbon server
+ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/jdk17/alpine/obiam/README.md
+++ b/dockerfiles/jdk17/alpine/obiam/README.md
@@ -1,0 +1,89 @@
+# Dockerfile for WSO2 Open Banking Identity & Access Management Accelerator Module #
+This section defines the step-by-step instructions to build an [Alpine](https://hub.docker.com/_/alpine/) Linux based Docker image for WSO2 Open Banking Identity & Access Management Module.
+
+## Prerequisites
+
+* [Docker](https://www.docker.com/get-docker) v20.10.10 or above
+* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
+* WSO2 Open Banking Identity & Access Management Accelerator Module pack downloaded through [WSO2 Updates 2.0](https://ob.docs.wso2.com/en/latest/install-and-setup/setting-up-servers/)
+* Download the WSO2 IS Connector to configure the Identity Server with the API Manager. Please go through this [link](https://ob.docs.wso2.com/en/latest/get-started/quick-start-guide/#installing-base-products) to find respective WSO2 IS Connector according to the API Manager version. Extract the dowloaded WSO2 IS Connector into your local machine.
+* Zip archive file of the Open Banking root and issuer certificates. 
+> Download the root and issuer [certificates](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/252018873/OB+Root+and+Issuing+Certificates+for+Sandbox).
+> Rename the `OB_SandBox_PP_Root.cer` as `root.cer`.
+> Rename the `OB_SandBox_PP_Issuing.cer` as `iss.cer`.
+> Zip the root.cer and iss.cer in one zip archive file.
+* Keystores directory of wso2 server certs of WSO2 Open Banking Docker Images. (https://github.com/wso2/docker-open-banking/raw/v3.0.0.10/dockerfiles/keystores)
+
+  + Host the downloaded artifacts locally or on a remote location.
+  > The hosted locations of artifacts will be passed as the build arguments when building the Docker image.<br>
+  > 1. **WSO2_OB_ACCELERATOR_DIST_URL** - Accelerator location
+  > 2. **OB_TRUSTED_CERTS_URL** - Zip archive location of the certificates of WSO2 Open Banking root and issuer
+  > 3. **WSO2_OB_KEYSTORES_URL** - Location of keystores folder of wso2 server certs
+
+
+## How to build an image and run
+
+##### 1. Checkout this repository into your local machine using the following Git client command.
+
+```
+git clone https://github.com/wso2/docker-open-banking.git
+```
+
+> The local copy of the `jdk17/dockerfiles/alpine/obiam` directory will be referred to as `OBIAM_DOCKERFILE_HOME` from this point onwards.
+
+##### 2. Build the Docker image.
+
+- Navigate to `<OBIAM_DOCKERFILE_HOME>` directory. <br>
+  Execute `docker build` command as shown below.
+    + `docker build --build-arg BASE_PRODUCT_VERSION=<IS BASE PRODUCT VERSION> --build-arg WSO2_OB_ACCELERATOR_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> --build-arg OB_TRUSTED_CERTS_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> --build-arg WSO2_OB_KEYSTORES_URL=<URL_OF_THE_HOSTED_LOCATION/FOLDER_NAME> -t wso2-obiam:3.0.0-alpine-jdk17 .` <br>
+    > eg:- **Hosted locally**: `docker build --build-arg BASE_PRODUCT_VERSION=6.0.0 --build-arg WSO2_OB_ACCELERATOR_DIST_URL=http://localhost:8000/wso2-obiam-accelerator-3.0.0.tar.gz --build-arg OB_TRUSTED_CERTS_URL=http://localhost:8000/ob-cert.zip --build-arg WSO2_OB_KEYSTORES_URL=https://github.com/wso2/docker-open-banking/raw/v3.0.0.10/dockerfiles/keystores  -t wso2-obiam:3.0.0-alpine-jdk17 .` <br><br>
+    >  eg:- **Hosted remotely**: `docker build --build-arg BASE_PRODUCT_VERSION=6.0.0 --build-arg WSO2_OB_ACCELERATOR_DIST_URL=http://<public_ip:port>/wso2-obiam-accelerator-3.0.0.tar.gz --build-arg OB_TRUSTED_CERTS_URL=http://<public_ip:port>/ob-cert.zip --build-arg WSO2_OB_KEYSTORES_URL=https://github.com/wso2/docker-open-banking/raw/v3.0.0.10/dockerfiles/keystores  -t wso2-obiam:3.0.0-alpine-jdk17 .`
+  
+##### 3. Running the Docker image.
+if you are only using the WSO2 Open Banking Identity Server, please run the below command.
+> - `docker run -it -p 9446:9446 wso2-obiam:3.0.0-alpine-jdk17`
+
+If you are using WSO2 Open Banking Identity Server and WSO2 Open Banking API Manager, please run the below command.
+> - `docker run -it -p 9446:9446 -v <IS_CONNECTOR_HOME>/dropins:/home/wso2carbon/wso2-artifact-volume/repository/components/dropins/ -v <IS_CONNECTOR_HOME>/webapps:/home/wso2carbon/wso2-artifact-volume/repository/deployment/server/webapps/ wso2-obiam:3.0.0-alpine-jdk17`
+> In here, <IS_CONNECTOR_HOME> refers to the root directory path of the extracted WSO2 IS Connector.
+
+##### 4. Accessing management console.
+
+- To access the management console, use the docker host IP and port 9446.
+    + `https:<DOCKER_HOST>:9446/carbon`
+    
+> In here, <DOCKER_HOST> refers to hostname or IP of the host machine on top of which containers are spawned.
+
+## How to update configurations
+
+Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
+As an example, steps required to change the port offset using `deployment.toml` is as follows:
+
+##### 1. Stop the Identity & Access Management Module container if it's already running.
+
+In WSO2 Open Banking Identity & Access Management Module 3.0.0 product distribution, `deployment.toml` configuration file <br>
+can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
+referred to as `<SOURCE_CONFIGS>/deployment.toml` and change the offset value under ports to 1.
+
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/deployment.toml`.
+
+```
+chmod o+r <SOURCE_CONFIGS>/deployment.toml
+```
+
+##### 3. Run the image by mounting the file to container as follows:
+
+```
+docker run \
+-p 9447:9447 \
+--volume <SOURCE_CONFIGS>/deployment.toml:<TARGET_CONFIGS>/deployment.toml \
+wso2-obiam:3.0.0-alpine-jdk17
+```
+
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2is-5.11.0/repository/conf folder of the container.
+
+## Docker command usage references
+
+* [Docker build command reference](https://docs.docker.com/engine/reference/commandline/build/)
+* [Docker run command reference](https://docs.docker.com/engine/reference/run/)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)

--- a/dockerfiles/jdk17/ubuntu/obiam-uk/Dockerfile
+++ b/dockerfiles/jdk17/ubuntu/obiam-uk/Dockerfile
@@ -1,0 +1,117 @@
+# ----------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# ----------------------------------------------------------------------------------------
+
+ARG BASE_DOCKER_IMAGE_REGISTRY="docker.wso2.com"
+ARG BASE_PRODUCT_VERSION
+ARG ACCELERATOR_PRODUCT_VERSION=3.0.0.0-is${BASE_PRODUCT_VERSION}.0-jdk17
+# set base Docker image to WSO2 Open Banking Identity Server Ubuntu Docker image
+FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2-obiam:${ACCELERATOR_PRODUCT_VERSION}
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v3.0.0.10"
+
+# set Docker image build arguments
+# build arguments for user/group configurations
+ARG USER=wso2carbon
+ARG USER_ID=802
+ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=802
+ARG USER_HOME=/home/${USER}
+# build arguments for WSO2 product installation
+ARG WSO2_SERVER_NAME=wso2is
+# declaring again BASE_PRODUCT_VERSION ARG to use in build stage
+ARG BASE_PRODUCT_VERSION
+ARG WSO2_OB_TOOLKIT_NAME=wso2-obiam-toolkit-uk
+ARG WSO2_OB_TOOLKIT_VERSION=1.0.0
+ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${BASE_PRODUCT_VERSION}
+ARG WSO2_OB_TOOLKIT=${WSO2_OB_TOOLKIT_NAME}-${WSO2_OB_TOOLKIT_VERSION}
+ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
+ARG WSO2_OB_TOOLKIT_DIR=${WSO2_SERVER_HOME}/${WSO2_OB_TOOLKIT}
+ARG WSO2_OB_TOOLKIT_DIST_URL
+# build argument for MOTD
+ARG MOTD="\n\
+Welcome to WSO2 Docker resources.\n\
+------------------------------------ \n\
+This Docker container comprises of The WSO2 Open Banking Solution, with its latest GA release \n\
+which is under The WSO2 Commercial License 1.0. \n\
+Read more about The WSO2 Commercial License, Version 1.0 here @ http://wso2.com/licenses \n"
+
+# configuration properties for deployment.toml file
+# server hostnames
+ARG IS_HOSTNAME=obiam
+ARG APIM_HOSTNAME=obam
+ARG BI_HOSTNAME=obbi
+# databases related properties
+ARG DB_TYPE=mysql
+ARG DB_USER=root
+ARG DB_PASS=root
+ARG DB_HOST=mysql
+ARG DB_DRIVER=com.mysql.jdbc.Driver
+ARG DB_APIMGT=openbank_apimgtdb
+ARG DB_USER_STORE=openbank_userdb
+ARG DB_AM_CONFIG=openbank_am_configdb
+ARG DB_GOV=openbank_govdb
+ARG DB_IS_CONFIG=openbank_iskm_configdb
+ARG DB_OPEN_BANKING_STORE=openbank_openbankingdb
+ARG DB_OB_REPORTING=openbank_ob_reporting_statsdb
+ARG DB_OB_REPORTING_SUMMARIZED=openbank_ob_reporting_summarizeddb
+
+# change user to root for elevated permissions to override inherited non-root user
+USER root
+
+# add Open Banking artifacts to base product
+RUN \
+    wget -O ${WSO2_OB_TOOLKIT}.zip "${WSO2_OB_TOOLKIT_DIST_URL}" \
+    && unzip -d ${WSO2_SERVER_HOME}/ ${WSO2_OB_TOOLKIT}.zip \
+    && rm -f ${WSO2_OB_TOOLKIT}.zip 
+
+# set configurations
+# read deployment.toml file
+ARG DEPLOYMENT_TOML_FILE=${WSO2_OB_TOOLKIT_DIR}/repository/resources/deployment.toml
+RUN \
+    cp ${WSO2_OB_TOOLKIT_DIR}/repository/resources/${WSO2_SERVER}-deployment-uk.toml ${DEPLOYMENT_TOML_FILE} \
+# configure hostnames
+    && sed -i -e 's|IS_HOSTNAME|'${IS_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|APIM_HOSTNAME|'${APIM_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|BI_HOSTNAME|'${BI_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
+# configure datasources
+    && sed -i -e 's|DB_APIMGT_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_APIMGT}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_GOV_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_GOV}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_IS_CONFIG_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_IS_CONFIG}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_USER_STORE_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_USER_STORE}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_OB_STORE_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_OPEN_BANKING_STORE}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_USER|'${DB_USER}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_PASS|'${DB_PASS}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_DRIVER|'${DB_DRIVER}'|g' ${DEPLOYMENT_TOML_FILE} \
+# copy deployment.toml file to original product pack location
+    && cp ${DEPLOYMENT_TOML_FILE} ${WSO2_SERVER_HOME}/repository/conf/ \
+    && rm ${DEPLOYMENT_TOML_FILE}
+
+# copy the WSO2 OB IAM UK Toolkit artifacts on top of WSO2 IS base product
+# copy open banking artifacts
+RUN\
+    cp -r ${WSO2_OB_TOOLKIT_DIR}/carbon-home/* "${WSO2_SERVER_HOME}"
+
+# change directory rights
+RUN \
+    chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME}/ \
+    && chown wso2carbon:wso2 /etc/motd
+
+# set the non-root user
+USER ${USER_ID}
+
+# set MOTD login message for open banking
+RUN echo "${MOTD}" > /etc/motd
+
+# expose ports
+EXPOSE 9446
+
+# initiate container and start WSO2 Carbon server
+ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/jdk17/ubuntu/obiam-uk/README.md
+++ b/dockerfiles/jdk17/ubuntu/obiam-uk/README.md
@@ -1,0 +1,79 @@
+# Dockerfile for WSO2 Open Banking Identity & Access Management UK Toolkit Module
+This section defines the step-by-step instructions to build an [Ubuntu](https://hub.docker.com/_/ubuntu/) Linux based Docker image for WSO2 Open Banking Identity & Access Management UK Toolkit Module with WSO2 IS 6.0.0.
+
+## Prerequisites
+
+* [Docker](https://www.docker.com/get-docker) v20.10.10 or above
+* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
+* WSO2 Open Banking Identity & Access Management UK Toolkit Module pack 
+* Download the WSO2 IS Connector to configure the Identity Server with the API Manager. Please go through this [link](https://ob.docs.wso2.com/en/latest/get-started/quick-start-guide/#installing-base-products) to find respective WSO2 IS Connector according to the API Manager version. Extract the dowloaded WSO2 IS Connector into your local machine.
+    + Host the downloaded artifacts locally or on a remote location.
+    > The hosted locations of artifacts will be passed as the build arguments when building the Docker image.<br>
+    > 1. **WSO2_OB_TOOLKIT_DIST_URL** - UK Toolkit location
+
+## How to build an image and run
+
+##### 1. Checkout this repository into your local machine using the following Git client command.
+
+```
+git clone https://github.com/wso2/docker-open-banking.git
+```
+
+> The local copy of the `jdk17/dockerfiles/ubuntu/obiam-uk` directory will be referred to as `OBIAM_UK_DOCKERFILE_HOME` from this point onwards.
+
+##### 2. Build the Docker image.
+
+- Navigate to `<OBIAM_UK_DOCKERFILE_HOME>` directory. <br>
+  Execute `docker build` command as shown below.
+    + `docker build --build-arg BASE_PRODUCT_VERSION=<IS BASE PRODUCT VERSION> --build-arg WSO2_OB_TOOLKIT_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> -t wso2-obiam-uk:1.0.0-jdk17 .` <br>
+    > eg:- **Hosted locally**: `docker build --build-arg BASE_PRODUCT_VERSION=6.0.0 --build-arg WSO2_OB_TOOLKIT_DIST_URL=http://localhost:8000/wso2-obiam-toolkit-uk-1.0.0.tar.gz -t wso2-obiam-uk:1.0.0-jdk17 .` <br><br>
+    > eg:- **Hosted remotely**: `docker build --build-arg BASE_PRODUCT_VERSION=6.0.0 --build-arg WSO2_OB_TOOLKIT_DIST_URL=http://<public_ip:port>/wso2-obiam-toolkit-uk-1.0.0.tar.gz -t wso2-obiam-uk:1.0.0-jdk17 .`
+
+##### 3. Running the Docker image.
+if you are only using the WSO2 Open Banking Identity Server, please run the below command.
+> - `docker run -it -p 9446:9446 wso2-obiam-uk:1.0.0-jdk17`
+
+If you are using WSO2 Open Banking Identity Server and WSO2 Open Banking API Manager,  please run the below command.
+> - `docker run -it -p 9446:9446 -v <IS_CONNECTOR_HOME>/dropins:/home/wso2carbon/wso2-artifact-volume/repository/components/dropins/ -v <IS_CONNECTOR_HOME>/webapps:/home/wso2carbon/wso2-artifact-volume/repository/deployment/server/webapps/ wso2-obiam-uk:1.0.0-jdk17`
+> In here, <IS_CONNECTOR_HOME> refers to the root directory path of the extracted WSO2 IS Connector.
+
+##### 4. Accessing management console.
+
+- To access the management console, use the docker host IP and port 9446.
+    + `https:<DOCKER_HOST>:9446/carbon`
+    
+> In here, <DOCKER_HOST> refers to hostname or IP of the host machine on top of which containers are spawned.
+
+## How to update configurations
+
+Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
+As an example, steps required to change the port offset using `deployment.toml` is as follows:
+
+##### 1. Stop the Identity & Access Management Module container if it's already running.
+
+In WSO2 Open Banking Identity & Access Management UK Toolkit 1.0.0 product distribution, `deployment.toml` configuration file <br>
+can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
+referred to as `<SOURCE_CONFIGS>/deployment.toml` and change the offset value under ports to 1.
+
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/deployment.toml`.
+
+```
+chmod o+r <SOURCE_CONFIGS>/deployment.toml
+```
+
+##### 3. Run the image by mounting the file to container as follows:
+
+```
+docker run \
+-p 9447:9447 \
+--volume <SOURCE_CONFIGS>/deployment.toml:<TARGET_CONFIGS>/deployment.toml \
+wso2-obiam-uk:1.0.0-jdk17
+```
+
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2is-6.0.0/repository/conf folder of the container.
+
+## Docker command usage references
+
+* [Docker build command reference](https://docs.docker.com/engine/reference/commandline/build/)
+* [Docker run command reference](https://docs.docker.com/engine/reference/run/)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)

--- a/dockerfiles/jdk17/ubuntu/obiam/Dockerfile
+++ b/dockerfiles/jdk17/ubuntu/obiam/Dockerfile
@@ -1,0 +1,140 @@
+# ----------------------------------------------------------------------------------------
+#
+# Copyright (c) 2022-2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# ----------------------------------------------------------------------------------------
+
+ARG BASE_DOCKER_IMAGE_REGISTRY="docker.wso2.com"
+ARG BASE_PRODUCT_VERSION  
+
+# set base Docker image to WSO2 Identity Server Ubuntu Docker image
+FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2is:${BASE_PRODUCT_VERSION}.0-jdk17
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v3.0.0.10"
+
+# set Docker image build arguments
+# build arguments for user/group configurations
+ARG USER=wso2carbon
+ARG USER_ID=802
+ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=802 
+ARG USER_HOME=/home/${USER}
+# build arguments for WSO2 product installation
+ARG WSO2_SERVER_NAME=wso2is
+# declaring again BASE_PRODUCT_VERSION ARG to use in build stage
+ARG BASE_PRODUCT_VERSION
+ARG WSO2_OB_ACCELERATOR_NAME=wso2-obiam-accelerator
+ARG WSO2_OB_ACCELERATOR_VERSION=3.0.0
+ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${BASE_PRODUCT_VERSION}
+ARG WSO2_OB_ACCELERATOR=${WSO2_OB_ACCELERATOR_NAME}-${WSO2_OB_ACCELERATOR_VERSION}
+ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
+ARG WSO2_OB_ACCELERATOR_DIR=${WSO2_SERVER_HOME}/${WSO2_OB_ACCELERATOR}
+ARG WSO2_OB_ACCELERATOR_DIST_URL
+ARG OB_TRUSTED_CERTS_URL
+ARG WSO2_OB_KEYSTORES_URL
+# build argument for MOTD
+ARG MOTD="\n\
+Welcome to WSO2 Docker resources.\n\
+------------------------------------ \n\
+This Docker container comprises of The WSO2 Open Banking Solution, with its latest GA release \n\
+which is under The WSO2 Commercial License 1.0. \n\
+Read more about The WSO2 Commercial License, Version 1.0 here @ http://wso2.com/licenses \n"
+
+# configuration properties for deployment.toml file
+# server hostnames
+ARG IS_HOSTNAME=obiam
+ARG APIM_HOSTNAME=obam
+ARG BI_HOSTNAME=obbi
+# databases related properties
+ARG DB_TYPE=mysql
+ARG DB_USER=root
+ARG DB_PASS=root
+ARG DB_HOST=mysql
+ARG DB_DRIVER=com.mysql.jdbc.Driver
+ARG DB_APIMGT=openbank_apimgtdb
+ARG DB_USER_STORE=openbank_userdb
+ARG DB_AM_CONFIG=openbank_am_configdb
+ARG DB_GOV=openbank_govdb
+ARG DB_IS_CONFIG=openbank_iskm_configdb
+ARG DB_OPEN_BANKING_STORE=openbank_openbankingdb
+ARG DB_OB_REPORTING=openbank_ob_reporting_statsdb
+ARG DB_OB_REPORTING_SUMMARIZED=openbank_ob_reporting_summarizeddb
+
+# change user to root for elevated permissions to override inherited non-root user
+USER root
+
+# add Open Banking artifacts to base product
+RUN \
+    wget -O ${WSO2_OB_ACCELERATOR}.zip "${WSO2_OB_ACCELERATOR_DIST_URL}" \
+    && unzip -d ${WSO2_SERVER_HOME}/ ${WSO2_OB_ACCELERATOR}.zip \
+    && rm -f ${WSO2_OB_ACCELERATOR}.zip \
+    && wget -O ob-cert.zip "${OB_TRUSTED_CERTS_URL}" \
+    && unzip -d ${USER_HOME} ob-cert.zip  \
+    && rm -f ob-cert.zip 
+
+# add keystores to base product 
+RUN if [ -n "$WSO2_OB_KEYSTORES_URL" ]; then wget -O private-keys.jks "${WSO2_OB_KEYSTORES_URL}/private-keys.jks" \
+    && yes | keytool -importkeystore -srckeystore ${USER_HOME}/private-keys.jks -destkeystore ${WSO2_SERVER_HOME}/repository/resources/security/wso2carbon.jks -srcalias wso2carbon-obiam -destalias wso2carbon -srcstorepass wso2carbon -deststorepass wso2carbon \
+    && rm -f private-keys.jks\
+    && wget -O public-certs.jks "${WSO2_OB_KEYSTORES_URL}/public-certs.jks" \
+    && keytool -importkeystore -srckeystore ${USER_HOME}/public-certs.jks -destkeystore ${WSO2_SERVER_HOME}/repository/resources/security/client-truststore.jks -srcstorepass wso2carbon -deststorepass wso2carbon \
+    && rm -r public-certs.jks ; fi 
+
+# set configurations
+# read deployment.toml file
+ARG DEPLOYMENT_TOML_FILE=${WSO2_OB_ACCELERATOR_DIR}/repository/resources/deployment.toml
+RUN \
+    cp ${WSO2_OB_ACCELERATOR_DIR}/repository/resources/${WSO2_SERVER}-deployment.toml ${DEPLOYMENT_TOML_FILE} \
+# configure hostnames
+    && sed -i -e 's|IS_HOSTNAME|'${IS_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|APIM_HOSTNAME|'${APIM_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|BI_HOSTNAME|'${BI_HOSTNAME}'|g' ${DEPLOYMENT_TOML_FILE} \
+# configure datasources
+    && sed -i -e 's|DB_APIMGT_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_APIMGT}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_GOV_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_GOV}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_IS_CONFIG_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_IS_CONFIG}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_USER_STORE_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_USER_STORE}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_OB_STORE_URL|jdbc:mysql://'${DB_HOST}':3306/'${DB_OPEN_BANKING_STORE}'?autoReconnect=true\&amp;useSSL=false|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_USER|'${DB_USER}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_PASS|'${DB_PASS}'|g' ${DEPLOYMENT_TOML_FILE} \
+    && sed -i -e 's|DB_DRIVER|'${DB_DRIVER}'|g' ${DEPLOYMENT_TOML_FILE} \
+# copy deployment.toml file to original product pack location
+    && cp ${DEPLOYMENT_TOML_FILE} ${WSO2_SERVER_HOME}/repository/conf/ \
+    && rm ${DEPLOYMENT_TOML_FILE}
+
+# copy the WSO2 OBIAM accelerator artifacts on top of WSO2 IS base product
+# remove old open banking artifacts from base product
+RUN \
+    find ${WSO2_SERVER_HOME}/repository/components/dropins -name "com.wso2.openbanking.*" -exec rm -rf {} \; \
+    && find ${WSO2_SERVER_HOME}/repository/components/lib -name "com.wso2.openbanking.*" -exec rm -rf {} \; \
+# copy open banking artifacts
+    && cp -r ${WSO2_OB_ACCELERATOR_DIR}/carbon-home/* ${WSO2_SERVER_HOME}/ \
+    && find ${WSO2_SERVER_HOME}/repository/components/dropins -name "org.wso2.carbon.identity.application.authentication.handler.identifier-*" -exec rm -rf {} \; 
+
+# add root and issuer certificates to client-truststore.jks
+RUN \
+    yes | keytool -import -alias ob-root -file root.cer -storetype JKS -keystore ${WSO2_SERVER_HOME}/repository/resources/security/client-truststore.jks  -storepass wso2carbon \
+    && yes | keytool -import -alias ob-issuer -file iss.cer -storetype JKS -keystore ${WSO2_SERVER_HOME}/repository/resources/security/client-truststore.jks  -storepass wso2carbon \
+    && rm -f root.cer iss.cer
+
+# change directory rights
+RUN \
+    chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME}/ \
+    && chown wso2carbon:wso2 /etc/motd
+
+# set the non-root user
+USER ${USER_ID}
+
+# set MOTD login message for open banking
+RUN echo "${MOTD}" > /etc/motd
+
+# expose ports
+EXPOSE 9446
+
+# initiate container and start WSO2 Carbon server
+ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/jdk17/ubuntu/obiam/README.md
+++ b/dockerfiles/jdk17/ubuntu/obiam/README.md
@@ -1,0 +1,89 @@
+# Dockerfile for WSO2 Open Banking Identity & Access Management Accelerator Module
+This section defines the step-by-step instructions to build an [Ubuntu](https://hub.docker.com/_/ubuntu/) Linux based Docker image for WSO2 Open Banking Identity & Access Management Module.
+
+## Prerequisites
+
+* [Docker](https://www.docker.com/get-docker) v20.10.10 or above
+* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
+* WSO2 Open Banking Identity & Access Management Accelerator Module pack downloaded through [WSO2 Updates 2.0](https://ob.docs.wso2.com/en/latest/install-and-setup/setting-up-servers/)
+* Download the WSO2 IS Connector to configure the Identity Server with the API Manager. Please go through this [link](https://ob.docs.wso2.com/en/latest/get-started/quick-start-guide/#installing-base-products) to find respective WSO2 IS Connector according to the API Manager version. Extract the dowloaded WSO2 IS Connector into your local machine.
+* Zip archive file of the Open Banking root and issuer certificates. 
+> Download the root and issuer [certificates](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/252018873/OB+Root+and+Issuing+Certificates+for+Sandbox).
+> Rename the `OB_SandBox_PP_Root.cer` as `root.cer`.
+> Rename the `OB_SandBox_PP_Issuing.cer` as `iss.cer`.
+> Zip the root.cer and iss.cer in one zip archive file.
+* Keystores directory of wso2 server certs of WSO2 Open Banking Docker Images. (https://github.com/wso2/docker-open-banking/raw/v3.0.0.10/dockerfiles/keystores)
+
+    + Host the downloaded artifacts locally or on a remote location.
+    > The hosted locations of artifacts will be passed as the build arguments when building the Docker image.<br>
+    > 1. **WSO2_OB_ACCELERATOR_DIST_URL** - Accelerator location
+    > 2. **OB_TRUSTED_CERTS_URL** - Zip archive location of the certificates of WSO2 Open Banking root and issuer
+    > 3. **WSO2_OB_KEYSTORES_URL** - location of keystores folder of wso2 server certs
+    
+
+## How to build an image and run
+
+##### 1. Checkout this repository into your local machine using the following Git client command.
+
+```
+git clone https://github.com/wso2/docker-open-banking.git
+```
+
+> The local copy of the `jdk17/dockerfiles/ubuntu/obiam` directory will be referred to as `OBIAM_DOCKERFILE_HOME` from this point onwards.
+
+##### 2. Build the Docker image.
+
+- Navigate to `<OBIAM_DOCKERFILE_HOME>` directory. <br>
+  Execute `docker build` command as shown below.
+    + `docker build  --build-arg BASE_PRODUCT_VERSION=<IS BASE PRODUCT VERSION> --build-arg WSO2_OB_ACCELERATOR_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> --build-arg OB_TRUSTED_CERTS_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> --build-arg WSO2_OB_KEYSTORES_URL=<URL_OF_THE_HOSTED_LOCATION/FOLDER_NAME> -t wso2-obiam:3.0.0-jdk17 .` <br>
+    > eg:- **Hosted locally**: `docker build --build-arg BASE_PRODUCT_VERSION=6.0.0 --build-arg WSO2_OB_ACCELERATOR_DIST_URL=http://localhost:8000/wso2-obiam-accelerator-3.0.0.tar.gz --build-arg OB_TRUSTED_CERTS_URL=http://localhost:8000/ob-cert.zip --build-arg WSO2_OB_KEYSTORES_URL=https://github.com/wso2/docker-open-banking/raw/v3.0.0.10/dockerfiles/keystores -t wso2-obiam:3.0.0-jdk17 .` <br><br>
+    > eg:- **Hosted remotely**: `docker build --build-arg BASE_PRODUCT_VERSION=6.0.0 --build-arg WSO2_OB_ACCELERATOR_DIST_URL=http://<public_ip:port>/wso2-obiam-accelerator-3.0.0.tar.gz --build-arg OB_TRUSTED_CERTS_URL=http://<public_ip:port>/ob-cert.zip --build-arg WSO2_OB_KEYSTORES_URL=https://github.com/wso2/docker-open-banking/raw/v3.0.0.10/dockerfiles/keystores -t wso2-obiam:3.0.0-jdk17 .`
+
+##### 3. Running the Docker image.
+if you are only using the WSO2 Open Banking Identity Server, please run the below command.
+> - `docker run -it -p 9446:9446 wso2-obiam:3.0.0-jdk17`
+
+If you are using WSO2 Open Banking Identity Server and WSO2 Open Banking API Manager,  please run the below command.
+> - `docker run -it -p 9446:9446 -v <IS_CONNECTOR_HOME>/dropins:/home/wso2carbon/wso2-artifact-volume/repository/components/dropins/ -v <IS_CONNECTOR_HOME>/webapps:/home/wso2carbon/wso2-artifact-volume/repository/deployment/server/webapps/ wso2-obiam:3.0.0-jdk17`
+> In here, <IS_CONNECTOR_HOME> refers to the root directory path of the extracted WSO2 IS Connector.
+
+##### 4. Accessing management console.
+
+- To access the management console, use the docker host IP and port 9446.
+    + `https:<DOCKER_HOST>:9446/carbon`
+    
+> In here, <DOCKER_HOST> refers to hostname or IP of the host machine on top of which containers are spawned.
+
+## How to update configurations
+
+Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
+As an example, steps required to change the port offset using `deployment.toml` is as follows:
+
+##### 1. Stop the Identity & Access Management Module container if it's already running.
+
+In WSO2 Open Banking Identity & Access Management Module 3.0.0 product distribution, `deployment.toml` configuration file <br>
+can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
+referred to as `<SOURCE_CONFIGS>/deployment.toml` and change the offset value under ports to 1.
+
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/deployment.toml`.
+
+```
+chmod o+r <SOURCE_CONFIGS>/deployment.toml
+```
+
+##### 3. Run the image by mounting the file to container as follows:
+
+```
+docker run \
+-p 9447:9447 \
+--volume <SOURCE_CONFIGS>/deployment.toml:<TARGET_CONFIGS>/deployment.toml \
+wso2-obiam:3.0.0-jdk17
+```
+
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2is-5.11.0/repository/conf folder of the container.
+
+## Docker command usage references
+
+* [Docker build command reference](https://docs.docker.com/engine/reference/commandline/build/)
+* [Docker run command reference](https://docs.docker.com/engine/reference/run/)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)


### PR DESCRIPTION
## Purpose
> This PR adds dockerfiles for jdk17.

## Goals
> Give capability to build docker images for jdk17.

Related issue: https://github.com/wso2/docker-open-banking/issues/164