### PR TITLE
Add custom entrypoint with wrapper script for adaptive.sh execution when required

### DIFF
--- a/dockerfiles/jdk17/alpine/obiam/Dockerfile
+++ b/dockerfiles/jdk17/alpine/obiam/Dockerfile
@@ -126,6 +126,10 @@ RUN \
 # change directory rights
 RUN chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME}/
 
+# Copy wrapper script to user home (adaptive.sh + docker-entrypoint.sh).
+# This wrapper script can be used to override the default entrypoint when using JDK17 with adaptive authentication.
+COPY --chown=wso2carbon:wso2 docker-entrypoint-ob.sh ${USER_HOME}/
+
 # set the non-root user
 USER ${USER_ID}
 

--- a/dockerfiles/jdk17/alpine/obiam/README.md
+++ b/dockerfiles/jdk17/alpine/obiam/README.md
@@ -47,6 +47,14 @@ If you are using WSO2 Open Banking Identity Server and WSO2 Open Banking API Man
 > - `docker run -it -p 9446:9446 -v <IS_CONNECTOR_HOME>/dropins:/home/wso2carbon/wso2-artifact-volume/repository/components/dropins/ -v <IS_CONNECTOR_HOME>/webapps:/home/wso2carbon/wso2-artifact-volume/repository/deployment/server/webapps/ wso2-obiam:3.0.0-alpine-jdk17`
 > In here, <IS_CONNECTOR_HOME> refers to the root directory path of the extracted WSO2 IS Connector.
 
+> Note: If adaptive authentication is required for the JDK17 docker container, add the following flag with the custom entrypoint path when starting the container. This will run the ```adaptive.sh``` script and download the necessary jars at the server start-up.
+>
+> ```--entrypoint "/home/wso2carbon/docker-entrypoint-ob.sh"```
+> 
+> Sample command:
+> 
+> ```docker run --entrypoint "/home/wso2carbon/docker-entrypoint-ob.sh" -it -p 9446:9446 wso2-obiam:3.0.0-alpine-jdk17```
+
 ##### 4. Accessing management console.
 
 - To access the management console, use the docker host IP and port 9446.

--- a/dockerfiles/jdk17/alpine/obiam/docker-entrypoint-ob.sh
+++ b/dockerfiles/jdk17/alpine/obiam/docker-entrypoint-ob.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+# Execute adaptive.sh script
+sh ${WSO2_SERVER_HOME}/bin/adaptive.sh "$@"
+
+# Check the exit status
+if [ $? -ne 0 ]; then
+    echo "Error executing adaptive.sh"
+    exit 1
+fi
+
+# Execute docker-entrypoint.sh script
+sh /home/wso2carbon/docker-entrypoint.sh

--- a/dockerfiles/jdk17/ubuntu/obiam/Dockerfile
+++ b/dockerfiles/jdk17/ubuntu/obiam/Dockerfile
@@ -127,6 +127,10 @@ RUN \
     chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME}/ \
     && chown wso2carbon:wso2 /etc/motd
 
+# Copy wrapper script to user home (adaptive.sh + docker-entrypoint.sh).
+# This wrapper script can be used to override the default entrypoint when using JDK17 with adaptive authentication.
+COPY --chown=wso2carbon:wso2 docker-entrypoint-ob.sh ${USER_HOME}/
+
 # set the non-root user
 USER ${USER_ID}
 

--- a/dockerfiles/jdk17/ubuntu/obiam/README.md
+++ b/dockerfiles/jdk17/ubuntu/obiam/README.md
@@ -47,6 +47,15 @@ If you are using WSO2 Open Banking Identity Server and WSO2 Open Banking API Man
 > - `docker run -it -p 9446:9446 -v <IS_CONNECTOR_HOME>/dropins:/home/wso2carbon/wso2-artifact-volume/repository/components/dropins/ -v <IS_CONNECTOR_HOME>/webapps:/home/wso2carbon/wso2-artifact-volume/repository/deployment/server/webapps/ wso2-obiam:3.0.0-jdk17`
 > In here, <IS_CONNECTOR_HOME> refers to the root directory path of the extracted WSO2 IS Connector.
 
+> Note: If adaptive authentication is required for the JDK17 docker container, add the following flag with the custom entrypoint path when starting the container. This will run the ```adaptive.sh``` script and download the necessary jars at the server start-up.
+>
+> ```--entrypoint "/home/wso2carbon/docker-entrypoint-ob.sh"```
+>
+> Sample command:
+>
+> ```docker run --entrypoint "/home/wso2carbon/docker-entrypoint-ob.sh" -it -p 9446:9446 wso2-obiam:3.0.0-alpine-jdk17```
+
+
 ##### 4. Accessing management console.
 
 - To access the management console, use the docker host IP and port 9446.

--- a/dockerfiles/jdk17/ubuntu/obiam/README.md
+++ b/dockerfiles/jdk17/ubuntu/obiam/README.md
@@ -53,7 +53,7 @@ If you are using WSO2 Open Banking Identity Server and WSO2 Open Banking API Man
 >
 > Sample command:
 >
-> ```docker run --entrypoint "/home/wso2carbon/docker-entrypoint-ob.sh" -it -p 9446:9446 wso2-obiam:3.0.0-alpine-jdk17```
+> ```docker run --entrypoint "/home/wso2carbon/docker-entrypoint-ob.sh" -it -p 9446:9446 wso2-obiam:3.0.0-ubuntu-jdk17```
 
 
 ##### 4. Accessing management console.

--- a/dockerfiles/jdk17/ubuntu/obiam/docker-entrypoint-ob.sh
+++ b/dockerfiles/jdk17/ubuntu/obiam/docker-entrypoint-ob.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+# Execute adaptive.sh script
+sh ${WSO2_SERVER_HOME}/bin/adaptive.sh "$@"
+
+# Check the exit status
+if [ $? -ne 0 ]; then
+    echo "Error executing adaptive.sh"
+    exit 1
+fi
+
+# Execute docker-entrypoint.sh script
+sh /home/wso2carbon/docker-entrypoint.sh


### PR DESCRIPTION
## Purpose
- This PR adds a custom entrypoint wrapper script to the JDK17 IAM images so if the client needs adaptive authentication supported with JDK17, the default entrypoint can be overridden using this provided custom entrypoint.
- This custom entrypoint is same as the default entrypoint but the ```adaptive.sh``` script will be executed before the original entrypoint script.
- If the client needs adaptive authentication, the following flag should be used with the path to the custom entrypoint file when starting the docker container. Otherwise, if the flag is not used, the default entrypoint will be used.

```
--entrypoint "/home/wso2carbon/docker-entrypoint-ob.sh"
```

- Example command:

```
docker run --entrypoint "/home/wso2carbon/docker-entrypoint-ob.sh" -it -p 9446:9446 --network ob-network --name obiam -v /Users/akilaa/wso2/ob-packs/2024/april-patch/22/docker/wso2is-extensions-1.6.8/dropins:/home/wso2carbon/wso2-artifact-volume/repository/components/dropins/ -v /Users/akilaa/wso2/ob-packs/2024/april-patch/22/docker/wso2is-extensions-1.6.8/webapps:/home/wso2carbon/wso2-artifact-volume/repository/deployment/server/webapps wso2-obiam:3.0.0-alpine-jdk17
```