### PR TITLE
Updating OB 3 docker images to pull base product images from new registry

### DIFF
--- a/dockerfiles/alpine/obam/Dockerfile
+++ b/dockerfiles/alpine/obam/Dockerfile
@@ -9,11 +9,12 @@
 #
 # ----------------------------------------------------------------------------------------
 
-ARG BASE_DOCKER_IMAGE_REGISTRY="docker.wso2.com"
+# Adding staging env url for testing purpose
+ARG BASE_DOCKER_IMAGE_REGISTRY="80a0414c-c5b1-4cd5-9acd-31e90002e61f.dev.wdt.choreoapps.dev"
 ARG BASE_PRODUCT_VERSION
 
 # set base Docker image to WSO2 API Manager Alpine Docker image
-FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2am:${BASE_PRODUCT_VERSION}.0-alpine
+FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2-apim/am:${BASE_PRODUCT_VERSION}.0-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v3.0.0.10"
 

--- a/dockerfiles/alpine/obbi/Dockerfile
+++ b/dockerfiles/alpine/obbi/Dockerfile
@@ -9,11 +9,12 @@
 #
 # ----------------------------------------------------------------------------------------
 
-ARG BASE_DOCKER_IMAGE_REGISTRY="docker.wso2.com"
+# Adding staging env url for testing purpose
+ARG BASE_DOCKER_IMAGE_REGISTRY="80a0414c-c5b1-4cd5-9acd-31e90002e61f.dev.wdt.choreoapps.dev"
 ARG BASE_PRODUCT_VERSION
 
 # set base Docker image to WSO2 Streaming Integrator Alpine Docker image
-FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2si:${BASE_PRODUCT_VERSION}.0-alpine
+FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2-integrator/si:${BASE_PRODUCT_VERSION}.0-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v3.0.0.10"
 

--- a/dockerfiles/alpine/obiam/Dockerfile
+++ b/dockerfiles/alpine/obiam/Dockerfile
@@ -9,11 +9,12 @@
 #
 # ----------------------------------------------------------------------------------------
 
-ARG BASE_DOCKER_IMAGE_REGISTRY="docker.wso2.com"
+# Adding staging env url for testing purpose
+ARG BASE_DOCKER_IMAGE_REGISTRY="80a0414c-c5b1-4cd5-9acd-31e90002e61f.dev.wdt.choreoapps.dev"
 ARG BASE_PRODUCT_VERSION
 
 # set base Docker image to WSO2 Identity Server Alpine Docker image
-FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2is:${BASE_PRODUCT_VERSION}.0-alpine
+FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2-is/is:${BASE_PRODUCT_VERSION}.0-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v3.0.0.10"
 

--- a/dockerfiles/jdk17/alpine/obiam/Dockerfile
+++ b/dockerfiles/jdk17/alpine/obiam/Dockerfile
@@ -9,11 +9,12 @@
 #
 # ----------------------------------------------------------------------------------------
 
-ARG BASE_DOCKER_IMAGE_REGISTRY="docker.wso2.com"
+# Adding staging env url for testing purpose
+ARG BASE_DOCKER_IMAGE_REGISTRY="80a0414c-c5b1-4cd5-9acd-31e90002e61f.dev.wdt.choreoapps.dev"
 ARG BASE_PRODUCT_VERSION
 
 # set base Docker image to WSO2 Identity Server Alpine Docker image
-FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2is:${BASE_PRODUCT_VERSION}.0-alpine-jdk17
+FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2-is/is:${BASE_PRODUCT_VERSION}.0-alpine-jdk17
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v3.0.0.10"
 

--- a/dockerfiles/jdk17/ubuntu/obiam/Dockerfile
+++ b/dockerfiles/jdk17/ubuntu/obiam/Dockerfile
@@ -9,11 +9,12 @@
 #
 # ----------------------------------------------------------------------------------------
 
-ARG BASE_DOCKER_IMAGE_REGISTRY="docker.wso2.com"
+# Adding staging env url for testing purpose
+ARG BASE_DOCKER_IMAGE_REGISTRY="80a0414c-c5b1-4cd5-9acd-31e90002e61f.dev.wdt.choreoapps.dev"
 ARG BASE_PRODUCT_VERSION  
 
 # set base Docker image to WSO2 Identity Server Ubuntu Docker image
-FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2is:${BASE_PRODUCT_VERSION}.0-jdk17
+FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2-is/is:${BASE_PRODUCT_VERSION}.0-jdk17
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v3.0.0.10"
 

--- a/dockerfiles/ubuntu/obam/Dockerfile
+++ b/dockerfiles/ubuntu/obam/Dockerfile
@@ -9,11 +9,12 @@
 #
 # ----------------------------------------------------------------------------------------
 
-ARG BASE_DOCKER_IMAGE_REGISTRY="docker.wso2.com"
+# Adding staging env url for testing purpose
+ARG BASE_DOCKER_IMAGE_REGISTRY="80a0414c-c5b1-4cd5-9acd-31e90002e61f.dev.wdt.choreoapps.dev"
 ARG BASE_PRODUCT_VERSION
 
 # set base Docker image to WSO2 API Manager Ubuntu Docker image
-FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2am:${BASE_PRODUCT_VERSION}.0
+FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2-apim/am:${BASE_PRODUCT_VERSION}.0
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v3.0.0.10"
 

--- a/dockerfiles/ubuntu/obbi/Dockerfile
+++ b/dockerfiles/ubuntu/obbi/Dockerfile
@@ -9,11 +9,12 @@
 #
 # ----------------------------------------------------------------------------------------
 
-ARG BASE_DOCKER_IMAGE_REGISTRY="docker.wso2.com"
+# Adding staging env url for testing purpose
+ARG BASE_DOCKER_IMAGE_REGISTRY="80a0414c-c5b1-4cd5-9acd-31e90002e61f.dev.wdt.choreoapps.dev"
 ARG BASE_PRODUCT_VERSION
 
 # set base Docker image to WSO2 Streaming Integrator Ubuntu Docker image
-FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2si:${BASE_PRODUCT_VERSION}.0
+FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2-integrator/si:${BASE_PRODUCT_VERSION}.0
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v3.0.0.10"
 

--- a/dockerfiles/ubuntu/obiam/Dockerfile
+++ b/dockerfiles/ubuntu/obiam/Dockerfile
@@ -9,11 +9,12 @@
 #
 # ----------------------------------------------------------------------------------------
 
-ARG BASE_DOCKER_IMAGE_REGISTRY="docker.wso2.com"
+# Adding staging env url for testing purpose
+ARG BASE_DOCKER_IMAGE_REGISTRY="80a0414c-c5b1-4cd5-9acd-31e90002e61f.dev.wdt.choreoapps.dev"
 ARG BASE_PRODUCT_VERSION  
 
 # set base Docker image to WSO2 Identity Server Ubuntu Docker image
-FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2is:${BASE_PRODUCT_VERSION}.0
+FROM ${BASE_DOCKER_IMAGE_REGISTRY}/wso2-is/is:${BASE_PRODUCT_VERSION}.0
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-open-banking/releases/tag/v3.0.0.10"
 


### PR DESCRIPTION
## Purpose
> Update OB3 docker images to pull base product images from the new docker registry. Since the base product images are not yet available in the production environment, this PR points to the staging environment. It will be updated after testing.